### PR TITLE
checkout repo param

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -26,3 +26,4 @@ jobs:
         git_commit_message: "This is an automated commit message from GitHub Actions."
         delete_old_environments: true
         clone_content: true
+        checkout_repo: false

--- a/action.yml
+++ b/action.yml
@@ -12,11 +12,11 @@ inputs:
     description: 'The machine name of your Pantheon site.'
     required: true
 
-  checkout_repo:
-    description: "A boolean for whether or not this composite step should checkout the Git repo. Set to false if a checkout has already been performed by earlier steps (such as ones that would process CSS/JS)"
-    required: false
-    default: true
-    type: boolean
+  # checkout_repo:
+  #   description: "A boolean for whether or not this composite step should checkout the Git repo. Set to false if a checkout has already been performed by earlier steps (such as ones that would process CSS/JS)"
+  #   required: false
+  #   default: true
+  #   type: boolean
 
   target_env:
     description: 'The Pantheon environment to which the deployment will be made. If left blank, the value used will be automatically derived. Pull requests will deploy to environments named "pr-[NUMBER]" and main/master branch commits will deploy to the Pantheon "dev" environment'

--- a/action.yml
+++ b/action.yml
@@ -119,7 +119,7 @@ runs:
             ssh-private-key: ${{ inputs.ssh_key }}
 
       - uses: actions/checkout@v4
-        if: ${{ inputs.checkout_repo }}
+        if: ${{ inputs.checkout_repo == 'true' }}
 
       - name: Install Terminus
         uses: pantheon-systems/terminus-github-actions@main

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,12 @@ inputs:
     description: 'The machine name of your Pantheon site.'
     required: true
 
+  checkout_repo:
+    description: "A boolean for whether or not this composite step should checkout the Git repo. Set to false if a checkout has already been performed by earlier steps (such as ones that would process CSS/JS)"
+    required: false
+    default: true
+    type: boolean
+
   target_env:
     description: 'The Pantheon environment to which the deployment will be made. If left blank, the value used will be automatically derived. Pull requests will deploy to environments named "pr-[NUMBER]" and main/master branch commits will deploy to the Pantheon "dev" environment'
     required: false
@@ -53,9 +59,6 @@ inputs:
     description: "The root directory of the site to be deployed relative to the repository root. The vast majority of users of this action should leave this value unchanged from the default. The action will use this value to change directories after checking out the repo."
     required: false
     default: ""
-
-  # todo checkout_repo:
-  #   description: "A boolean for whether or not this composite step should checkout the git repo. Set to false if a checkout has already been perf"
 
 runs:
     using: 'composite'
@@ -115,10 +118,8 @@ runs:
         with:
             ssh-private-key: ${{ inputs.ssh_key }}
 
-      # todo, make checkout conditional.
-      # Consumers might have checked out before calling this
-      # composite action.
       - uses: actions/checkout@v4
+        if: ${{ inputs.checkout_repo }}
 
       - name: Install Terminus
         uses: pantheon-systems/terminus-github-actions@main

--- a/action.yml
+++ b/action.yml
@@ -119,7 +119,7 @@ runs:
             ssh-private-key: ${{ inputs.ssh_key }}
 
       - uses: actions/checkout@v4
-        if: ${{ inputs.checkout_repo == 'true' }}
+       # if: ${{ inputs.checkout_repo == 'true' }}
 
       - name: Install Terminus
         uses: pantheon-systems/terminus-github-actions@main

--- a/action.yml
+++ b/action.yml
@@ -12,11 +12,11 @@ inputs:
     description: 'The machine name of your Pantheon site.'
     required: true
 
-  # checkout_repo:
-  #   description: "A boolean for whether or not this composite step should checkout the Git repo. Set to false if a checkout has already been performed by earlier steps (such as ones that would process CSS/JS)"
-  #   required: false
-  #   default: true
-  #   type: boolean
+  checkout_repo:
+    description: "A boolean for whether or not this composite step should checkout the Git repo. Set to false if a checkout has already been performed by earlier steps (such as ones that would process CSS/JS)"
+    required: false
+    default: true
+    type: boolean
 
   target_env:
     description: 'The Pantheon environment to which the deployment will be made. If left blank, the value used will be automatically derived. Pull requests will deploy to environments named "pr-[NUMBER]" and main/master branch commits will deploy to the Pantheon "dev" environment'
@@ -119,7 +119,7 @@ runs:
             ssh-private-key: ${{ inputs.ssh_key }}
 
       - uses: actions/checkout@v4
-       # if: ${{ inputs.checkout_repo == 'true' }}
+        if: ${{ inputs.checkout_repo }}
 
       - name: Install Terminus
         uses: pantheon-systems/terminus-github-actions@main

--- a/readme.md
+++ b/readme.md
@@ -150,7 +150,7 @@ For example, to use version 0.2.1 of this action, the step would look like this:
 
 By default this action will check out the code from the GitHub repository and push it to Pantheon.
 For many WordPress sites and Drupal sites, this is all that is needed.
-By setting `build_step: true` in the `pantheon.yml`, Pantheon will execute `composer install` and eventually `npm build` for compilation of CSS and JS assets needed for a theme(TODO, LINK NEEDED).
+By setting [`build_step: true` in the `pantheon.yml`](https://docs.pantheon.io/pantheon-yml#integrated-composer-build-step), Pantheon will execute `composer install` and eventually `npm build` for compilation of CSS and JS assets needed for a theme.
 
 However, some teams prefer to do these build steps in GitHub Actions before pushing to Pantheon.
 
@@ -163,9 +163,14 @@ Here's an example from a real site that uses Tailwind to prepare CSS in the site
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - run: "cd web/themes/stevector2024 && npm ci && npm run build"
-    - run: "cd web/themes/stevector2024/css && rm .gitignore"
-    - name: Deploy to Pantheon
+    # The custom theme for this site uses Tailwind to build the
+    # appropriate CSS file.
+    - run: "cd web/themes/my_custom_theme && npm ci && npm run build"
+    # deleting this small .gitignore that ignores compiled CSS
+    # from the GitHub repo will allow it to be committed and pushed
+    # to Pantheon in the later "push-to-pantheon" step.
+    - run: "cd web/themes/my_custom_theme/css && rm .gitignore"
+    - name: Push to Pantheon
       uses: stevector/push-to-pantheon@checkout_repo
       with:
         ssh_key: ${{ secrets.PANTHEON_SSH_KEY }}
@@ -176,11 +181,10 @@ Here's an example from a real site that uses Tailwind to prepare CSS in the site
 
 The important elements to note are that:
 
-- the first step is checking out the code from the GitHub repository.
-- the `cd` commands are used to change directories to the location of the `package.json` file.
-- the `npm ci` command is used to install the dependencies listed in the `package.json` file.
-- the `npm run build` command is used to run the build script defined in the `package.json` file.
-- the `rm .gitignore` command is used to remove the `.gitignore` file from the `css` directory. This allows the CSS to be committed later by the action.
+- The first step in this job is the checking out the code from the GitHub repository. Since the repo is checked out in this first step, it should not be checked out again by the `push-to-pantheon` step.
+- The next step builds a CSS file that will be used by Drupal. It does so by using `cd` to go to the theme directory and processing a `package.json`
+ that lives there. It is a question of preference for teams as to whether they want such `package.json` files living in their custom themes, the root of their projects or elsewhere.
+- After the CSS file is built a small `.gitignore` file is removed so that `push-to-pantheon` will detect, commit, and push the generated CSS that is not meant to be version controlled on GitHub.
 - the `checkout_repo` parameter is set to `false` in the step that uses this action. This prevents the action from checking out the code again, which would undo the work done in the previous steps.
 
 ### Concurrency

--- a/readme.md
+++ b/readme.md
@@ -148,7 +148,40 @@ For example, to use version 0.2.1 of this action, the step would look like this:
 
 ### Additional build steps like `composer install` and `npm build`
 
-[_todo: explain_](https://github.com/stevector-streaming/dtp/issues/54)
+By default this action will check out the code from the GitHub repository and push it to Pantheon.
+For many WordPress sites and Drupal sites, this is all that is needed.
+By setting `build_step: true` in the `pantheon.yml`, Pantheon will execute `composer install` and eventually `npm build` for compilation of CSS and JS assets needed for a theme(TODO, LINK NEEDED).
+
+However, some teams prefer to do these build steps in GitHub Actions before pushing to Pantheon.
+
+That use case can be accommodated by adding additional steps to the workflow before the step that uses this action.
+
+Here's an example from a real site that uses Tailwind to prepare CSS in the site's custom theme.
+
+```
+  push-to-pantheon:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: "cd web/themes/stevector2024 && npm ci && npm run build"
+    - run: "cd web/themes/stevector2024/css && rm .gitignore"
+    - name: Deploy to Pantheon
+      uses: stevector/push-to-pantheon@checkout_repo
+      with:
+        ssh_key: ${{ secrets.PANTHEON_SSH_KEY }}
+        machine_token: ${{ secrets.TERMINUS_MACHINE_TOKEN }}
+        site: ${{ vars.PANTHEON_SITE }}
+        checkout_repo: false
+```
+
+The important elements to note are that:
+
+- the first step is checking out the code from the GitHub repository.
+- the `cd` commands are used to change directories to the location of the `package.json` file.
+- the `npm ci` command is used to install the dependencies listed in the `package.json` file.
+- the `npm run build` command is used to run the build script defined in the `package.json` file.
+- the `rm .gitignore` command is used to remove the `.gitignore` file from the `css` directory. This allows the CSS to be committed later by the action.
+- the `checkout_repo` parameter is set to `false` in the step that uses this action. This prevents the action from checking out the code again, which would undo the work done in the previous steps.
 
 ### Concurrency
 

--- a/readme.md
+++ b/readme.md
@@ -62,10 +62,19 @@ The machine name of your Pantheon site.
 
 #### `delete_old_environments`
 
-If set to true, Multidev environments associated with closed pull requests will be deleted after deployment completes. It is recommended to set this parameter to true for workflows that run after merges to the main branch.
+If set to true, Multidev environments associated with closed pull requests will be deleted after deployment completes. It is recommended to set this parameter to `true` for workflows that run after merges to the main branch.
 
 ```yml
    default: false
+   type: boolean
+```
+
+#### `checkout_repo`
+
+A boolean for whether or not this composite step should checkout the Git repo. Set to `false` if a checkout has already been performed by earlier steps (such as ones that would process CSS/JS).
+
+```yml
+   default: true
    type: boolean
 ```
 


### PR DESCRIPTION
Add a parameter to specify that the step should not do a checkout. This option is needed for situations where something like `npm run build` is executed prior to this composite step.

- [x] Update the `action.yml` file to add the param
- [x] Confirm behavior works on by making personal site execute `npm run build` in this way (In progress in https://github.com/stevector/stevector-composed/pull/153)
- [x] Update readme list of parameters
- [ ] Update readme to explain `npm run build`