### PR TITLE
Delete GitHub Environments when deleting Multidevs

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -80,7 +80,7 @@ jobs:
 
         - name: Set short branch name
           id: vars
-          run: echo "short_ref_name=$(echo ${{ github.ref_name }} | sed 's/[^a-zA-Z0-9-]//g' | cut -c1-6)" >> $GITHUB_OUTPUT
+          run: echo "short_ref_name=$(echo ${{ github.ref_name }} | sed 's/[^a-zA-Z0-9-]//g' | cut -c1-8)" >> $GITHUB_OUTPUT
 
         - name: deploy to Pantheon
           uses: ./

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -15,6 +15,14 @@ on:
         options:
           - 'Yes'
           - 'No'
+      run_cleanup:
+        description: 'Run cleanup after successful deploy?'
+        required: true
+        default: 'No'
+        type: choice
+        options:
+          - 'Yes'
+          - 'No'
 
 jobs:
   test_workflow_no_terminus_install:
@@ -57,6 +65,7 @@ jobs:
         git_user_email: "test@example.com"
         git_commit_message: "This is a manual test deployment from GitHub Actions."
         clone_content: true
+        delete_old_environments: ${{ github.event.inputs.run_cleanup == 'Yes' }}
 
   test_workflow_with_terminus_install:
     name: Test Deploy with Terminus Install
@@ -85,3 +94,5 @@ jobs:
             git_user_email: "test@example.com"
             git_commit_message: "This is a manual test deployment from GitHub Actions."
             clone_content: true
+            delete_old_environments: ${{ github.event.inputs.run_cleanup == 'Yes' }}
+       

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -30,7 +30,7 @@ jobs:
     if: ${{ github.event.inputs.install_terminus == 'No' }}
     permissions:
       deployments: write
-      contents: read
+      contents: write
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
@@ -72,7 +72,7 @@ jobs:
     if: ${{ github.event.inputs.install_terminus == 'Yes' }}
     permissions:
         deployments: write
-        contents: read
+        contents: write
     runs-on: ubuntu-latest
     steps:
         - name: Checkout Repository

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Set short branch name
       id: vars
-      run: echo "short_ref_name=$(echo ${{ github.ref_name }} | sed 's/[^a-zA-Z0-9-]//g' | cut -c1-6)" >> $GITHUB_OUTPUT
+      run: echo "short_ref_name=$(echo ${{ github.ref_name }} | sed 's/[^a-zA-Z0-9-]//g' | cut -c1-8)" >> $GITHUB_OUTPUT
 
     - name: deploy to Pantheon
       uses: ./

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -59,7 +59,7 @@ jobs:
         ssh_key: ${{ secrets.PANTHEON_SSH_KEY }}
         machine_token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
         site: dtp-nearly-empty-site
-        target_env: "test-${{ steps.vars.outputs.short_ref_name }}"
+        target_env: "wd-${{ steps.vars.outputs.short_ref_name }}"
         relative_site_root: ".github/testing_fixtures/dtp-nearly-empty-site"
         git_user_name: "Test Name"
         git_user_email: "test@example.com"
@@ -88,7 +88,7 @@ jobs:
             ssh_key: ${{ secrets.PANTHEON_SSH_KEY }}
             machine_token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
             site: dtp-nearly-empty-site
-            target_env: "test-${{ steps.vars.outputs.short_ref_name }}"
+            target_env: "wd-${{ steps.vars.outputs.short_ref_name }}"
             relative_site_root: ".github/testing_fixtures/dtp-nearly-empty-site"
             git_user_name: "Test Name"
             git_user_email: "test@example.com"

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,9 +1,6 @@
 name: Shellcheck
 on:
   push:
-    branches:
-      - 0.x
-      - 1.x
     paths:
       - '/scripts/**'
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -2,7 +2,8 @@ name: Shellcheck
 on:
   push:
     branches:
-      - main
+      - 0.x
+      - 1.x
     paths:
       - '/scripts/**'
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - '/scripts/**'
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     name: Run Shellcheck on Scripts

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,17 @@
+name: Shellcheck
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '/scripts/**'
+
+jobs:
+  shellcheck:
+    name: Run Shellcheck on Scripts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run Shellcheck
+        run: shellcheck scripts/*.sh

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -3,6 +3,7 @@ on:
   push:
     paths:
       - '/scripts/**'
+      - '/.github/workflows/shellcheck.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -2,8 +2,8 @@ name: Shellcheck
 on:
   push:
     paths:
-      - '/scripts/**'
-      - '/.github/workflows/shellcheck.yml'
+      - 'scripts/**'
+      - '.github/workflows/shellcheck.yml'
 
 permissions:
   contents: read

--- a/action.yml
+++ b/action.yml
@@ -118,7 +118,7 @@ runs:
         with:
           step: start
           token: ${{ github.token }}
-          env: ${{ env.PANTHEON_TARGET_ENV }}
+          env: ${{ env.PANTHEON_TARGET_ENV }}-${{ inputs.site }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Configure SSH key

--- a/action.yml
+++ b/action.yml
@@ -227,8 +227,13 @@ runs:
             cd ${SITE_ROOT}
           fi
 
+          echo "Deleting Pantheon PR multidev environment..."
           terminus build:env:delete:pr $PANTHEON_SITE --yes
-        # todo, also add deletion of GitHub environments representation
-        # https://github.com/bobheadxi/deployments?tab=readme-ov-file#step-delete-env
 
-          
+          echo "Finding closed PRs to clean up GitHub environments..."
+          CLOSED_PRS=$(gh pr list --state closed --json number --jq '.[].number')
+          for PR_NUM in "${CLOSED_PRS}"; do
+            ENV_NAME="pr-$PR_NUM"
+            echo "Attempting to delete GitHub environment: $ENV_NAME..."
+            gh api --method DELETE "repos/${{ github.repository }}/environments/$ENV_NAME"
+          done        

--- a/action.yml
+++ b/action.yml
@@ -187,6 +187,7 @@ runs:
           PANTHEON_SOURCE_ENV: ${{ inputs.source_env }}
           SITE_ROOT: ${{ inputs.relative_site_root }}
           PANTHEON_COMMIT_MESSAGE: ${{ inputs.git_commit_message }}
+          GITHUB_TOKEN: ${{ github.token }}
           # todo, might need to make this configurable too.
           # the default in build tools is 180. But that's regularly failing
           # on a small personal site.

--- a/action.yml
+++ b/action.yml
@@ -223,4 +223,5 @@ runs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           MULTIDEV_DELETE_PATTERN: pr-
           PANTHEON_TARGET_ENV: ${{ env.PANTHEON_TARGET_ENV }}
-        run: ${{ github.workspace }}/scripts/cleanup.sh
+          WORKSPACE: ${{ github.workspace }}
+        run: $WORKSPACE/scripts/cleanup.sh

--- a/action.yml
+++ b/action.yml
@@ -118,7 +118,7 @@ runs:
         with:
           step: start
           token: ${{ github.token }}
-          env: ${{ env.PANTHEON_TARGET_ENV }}-${{ inputs.site }}
+          env: ${{ env.PANTHEON_TARGET_ENV }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Configure SSH key
@@ -210,7 +210,7 @@ runs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           # todo, how does this work when there is a step above with the id of "deployment" not "deployment_id"
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          env: ${{ env.PANTHEON_TARGET_ENV }}-${{ inputs.site }}
+          env: ${{ env.PANTHEON_TARGET_ENV }}
           env_url: https://${{ env.PANTHEON_TARGET_ENV }}-${{ inputs.site }}.pantheonsite.io
       - name: Deleting old multidevs
         if: ${{ inputs.delete_old_environments == 'true' && steps.deploy_to_pantheon.outcome == 'success' }}

--- a/action.yml
+++ b/action.yml
@@ -219,6 +219,7 @@ runs:
           PANTHEON_SITE: ${{ inputs.site }}
           GITHUB_TOKEN: ${{ github.token }}
           SITE_ROOT: ${{ inputs.relative_site_root }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           # Delete old multidevs
           set +e
@@ -235,5 +236,5 @@ runs:
           for PR_NUM in "${CLOSED_PRS}"; do
             ENV_NAME="pr-$PR_NUM"
             echo "Attempting to delete GitHub environment: $ENV_NAME..."
-            gh api --method DELETE "repos/${{ github.repository }}/environments/$ENV_NAME"
+            gh api --method DELETE "repos/$GITHUB_REPOSITORY/environments/$ENV_NAME"
           done        

--- a/action.yml
+++ b/action.yml
@@ -169,6 +169,7 @@ runs:
           set +e
           if [ -n "$SITE_ROOT" ]; then
             cd ${SITE_ROOT}
+            rm -rf .git
             git init -b main
             git add .
             git commit -m "Initial commit for deployment"

--- a/action.yml
+++ b/action.yml
@@ -174,7 +174,6 @@ runs:
             git add .
             git commit -m "Initial commit for deployment"
             echo "this origin setting is a hack to get past the 'inferring' of a git provider in build tools"
-            git remote add origin https://github.com/${{ github.repository }}
           else
             git fetch --unshallow origin
           fi

--- a/action.yml
+++ b/action.yml
@@ -228,3 +228,7 @@ runs:
           fi
 
           terminus build:env:delete:pr $PANTHEON_SITE --yes
+        # todo, also add deletion of GitHub environments representation
+        # https://github.com/bobheadxi/deployments?tab=readme-ov-file#step-delete-env
+
+          

--- a/action.yml
+++ b/action.yml
@@ -216,25 +216,11 @@ runs:
         if: ${{ inputs.delete_old_environments == 'true' && steps.deploy_to_pantheon.outcome == 'success' }}
         shell: bash
         env:
+          DELETE_OLD_MULTIDEVS: ${{ inputs.delete_old_environments }}
           PANTHEON_SITE: ${{ inputs.site }}
           GITHUB_TOKEN: ${{ github.token }}
           SITE_ROOT: ${{ inputs.relative_site_root }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-        run: |
-          # Delete old multidevs
-          set +e
-
-          if [ -n "$SITE_ROOT" ]; then
-            cd ${SITE_ROOT}
-          fi
-
-          echo "Deleting Pantheon PR multidev environment..."
-          terminus build:env:delete:pr $PANTHEON_SITE --yes
-
-          echo "Finding closed PRs to clean up GitHub environments..."
-          CLOSED_PRS=$(gh pr list --state closed --json number --jq '.[].number')
-          for PR_NUM in "${CLOSED_PRS}"; do
-            ENV_NAME="pr-$PR_NUM"
-            echo "Attempting to delete GitHub environment: $ENV_NAME..."
-            gh api --method DELETE "repos/$GITHUB_REPOSITORY/environments/$ENV_NAME"
-          done        
+          MULTIDEV_DELETE_PATTERN: pr-
+          PANTHEON_TARGET_ENV: ${{ env.PANTHEON_TARGET_ENV }}
+        run: ${{ github.workspace }}/scripts/cleanup.sh

--- a/action.yml
+++ b/action.yml
@@ -169,7 +169,6 @@ runs:
           set +e
           if [ -n "$SITE_ROOT" ]; then
             cd ${SITE_ROOT}
-            rm -rf .git
             git init -b main
             git add .
             git commit -m "Initial commit for deployment"

--- a/action.yml
+++ b/action.yml
@@ -173,6 +173,7 @@ runs:
             git add .
             git commit -m "Initial commit for deployment"
             echo "this origin setting is a hack to get past the 'inferring' of a git provider in build tools"
+            git remote add origin https://github.com/${{ github.repository }}
           else
             git fetch --unshallow origin
           fi

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -20,9 +20,7 @@ delete_github_environment() {
   if [ -n "$DEPLOYMENT_IDS" ]; then
     for DEPLOYMENT_ID in $DEPLOYMENT_IDS; do
       echo "  - Deleting deployment ID ${DEPLOYMENT_ID}..."
-      # Deployments must be inactive before they can be deleted.
       gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" -f state='inactive' -f description='Deployment is being deleted.' > /dev/null
-      # Now delete the deployment itself.
       gh api --method DELETE "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}"
     done
   else
@@ -42,7 +40,6 @@ if [ -n "$SITE_ROOT" ]; then
   echo "Re-initializing git in ${SITE_ROOT} to ensure correct repository context..."
   rm -rf .git
   git init -b main >/dev/null 2>&1
-  git remote add origin "https://github.com/${GITHUB_REPOSITORY}" >/dev/null 2>&1
 fi
 
 echo "Deleting stale Pantheon PR multidev environments..."

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -32,14 +32,8 @@ delete_github_environment() {
   gh api --method DELETE "repos/${GITHUB_REPOSITORY}/environments/${ENV_NAME}"
 }
 
-# The terminus build:env:delete:pr command relies on the git history to find
-# pull requests. If we are running in a fixture directory, we need to
-# re-initialize git to ensure it points to the correct repository.
 if [ -n "$SITE_ROOT" ]; then
   cd "${SITE_ROOT}" || return
-  echo "Re-initializing git in ${SITE_ROOT} to ensure correct repository context..."
-  rm -rf .git
-  git init -b main >/dev/null 2>&1
 fi
 
 echo "Deleting stale Pantheon PR multidev environments..."

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -58,6 +58,7 @@ OLDEST_ENVIRONMENTS=$(echo "$ALL_ENVS" \
   | grep -v live \
   | sort \
   | grep "$MULTIDEV_DELETE_PATTERN" \
+  | grep -v '^pr-' \
   | sed -e '$d')
 
 # Exit if there are no environments to delete.

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -3,11 +3,11 @@ set +e
 
 # Delete old multidevs
 if [ -n "$SITE_ROOT" ]; then
-  cd ${SITE_ROOT}
+  cd "${SITE_ROOT}" || return
 fi
 
 echo "Deleting Pantheon PR multidev environment..."
-terminus build:env:delete:pr $PANTHEON_SITE --yes
+terminus build:env:delete:pr "$PANTHEON_SITE" --yes
 
 echo "Deleting GitHub deployment environment: ${PANTHEON_TARGET_ENV}..."
 gh api --method DELETE "repos/${GITHUB_REPOSITORY}/environments/${PANTHEON_TARGET_ENV}" || true
@@ -40,7 +40,7 @@ fi
 
 # Go ahead and delete the oldest environments.
 for ENV_TO_DELETE in $OLDEST_ENVIRONMENTS; do
-  terminus env:delete $TERMINUS_SITE.$ENV_TO_DELETE --delete-branch --yes
+  terminus env:delete "${TERMINUS_SITE}.${ENV_TO_DELETE}" --delete-branch --yes
 
   # Delete related GitHub deployment environment
   if [ -n "$GITHUB_REPOSITORY" ]; then

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -51,7 +51,7 @@ fi
 
 # List all environments, filter out the standard dev/test/live, find the ones
 # that match our deletion pattern, and then exclude the most recent one.
-ALL_ENVS=$(terminus env:list "$TERMINUS_SITE" --format=list)
+ALL_ENVS=$(terminus env:list "$PANTHEON_SITE" --format=list)
 OLDEST_ENVIRONMENTS=$(echo "$ALL_ENVS" \
   | grep -v dev \
   | grep -v test \
@@ -68,7 +68,9 @@ fi
 
 # Go ahead and delete the oldest environments.
 for ENV_TO_DELETE in $OLDEST_ENVIRONMENTS; do
+    echo "Deleting Pantheon environment: ${ENV_TO_DELETE}..."
     if terminus env:info "${PANTHEON_SITE}.${ENV_TO_DELETE}" > /dev/null 2>&1; then
+        echo "Found Pantheon environment ${ENV_TO_DELETE}, proceeding with deletion."
         terminus env:delete "${PANTHEON_SITE}.${ENV_TO_DELETE}" --delete-branch --yes
         if [ -n "$GITHUB_REPOSITORY" ]; then
             delete_github_environment "$ENV_TO_DELETE"

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set +e
+
+# Delete old multidevs
+if [ -n "$SITE_ROOT" ]; then
+  cd ${SITE_ROOT}
+fi
+
+echo "Deleting Pantheon PR multidev environment..."
+terminus build:env:delete:pr $PANTHEON_SITE --yes
+
+echo "Deleting GitHub deployment environment: ${PANTHEON_TARGET_ENV}..."
+gh api --method DELETE "repos/${GITHUB_REPOSITORY}/environments/${PANTHEON_TARGET_ENV}" || true
+
+# Only delete old environments if there is a pattern defined to
+# match environments eligible for deletion. Otherwise, delete the
+# current multidev environment immediately.
+#
+# To use this feature, set MULTIDEV_DELETE_PATTERN to 'pr-' or similar
+# in the CI server environment variables.
+if [ -z "$MULTIDEV_DELETE_PATTERN" ] || [ -z "$DELETE_OLD_MULTIDEVS" ] || [ "$DELETE_OLD_MULTIDEVS" != "true" ]; then
+  echo "No MULTIDEV_DELETE_PATTERN set or delete old multidevs was not set to true. Skipping deletion of old environments..."
+  exit 0
+fi
+
+# List all but the newest two environments.
+ALL_ENVS=$(terminus env:list "$TERMINUS_SITE" --format=list)
+OLDEST_ENVIRONMENTS=$(echo "$ALL_ENVS" \
+  | grep -v dev \
+  | grep -v test \
+  | grep -v live \
+  | sort \
+  | grep "$MULTIDEV_DELETE_PATTERN" \
+  | sed -e '$d')
+
+# Exit if there are no environments to delete
+if [ -z "$OLDEST_ENVIRONMENTS" ] ; then
+  exit 0
+fi
+
+# Go ahead and delete the oldest environments.
+for ENV_TO_DELETE in $OLDEST_ENVIRONMENTS; do
+  terminus env:delete $TERMINUS_SITE.$ENV_TO_DELETE --delete-branch --yes
+
+  # Delete related GitHub deployment environment
+  if [ -n "$GITHUB_REPOSITORY" ]; then
+    echo "Deleting GitHub deployment environment: ${ENV_TO_DELETE}..."
+    if ! gh api "repos/${GITHUB_REPOSITORY}/environments/${ENV_TO_DELETE}" > /dev/null 2>&1; then
+      echo "GitHub environment $ENV_TO_DELETE does not exist, skipping deletion."
+      continue
+    fi
+    gh api --method DELETE "repos/${GITHUB_REPOSITORY}/environments/${ENV_TO_DELETE}"
+  else 
+    echo "Skipping GitHub deletion for ${ENV_TO_DELETE} — GITHUB_TOKEN or GITHUB_REPOSITORY not set."
+  fi
+done

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -74,13 +74,14 @@ fi
 
 # Go ahead and delete the oldest environments.
 for ENV_TO_DELETE in $OLDEST_ENVIRONMENTS; do
-  # Delete the Pantheon multidev environment.
-  terminus env:delete "${TERMINUS_SITE}.${ENV_TO_DELETE}" --delete-branch --yes
-
-  # Delete the related GitHub deployment environment.
-  if [ -n "$GITHUB_REPOSITORY" ]; then
-    delete_github_environment "$ENV_TO_DELETE"
-  else
-    echo "Skipping GitHub deletion for ${ENV_TO_DELETE} — GITHUB_TOKEN or GITHUB_REPOSITORY not set."
-  fi
+    if terminus env:info "${PANTHEON_SITE}.${ENV_TO_DELETE}" > /dev/null 2>&1; then
+        terminus env:delete "${TERMINUS_SITE}.${ENV_TO_DELETE}" --delete-branch --yes
+        if [ -n "$GITHUB_REPOSITORY" ]; then
+            delete_github_environment "$ENV_TO_DELETE"
+        else
+            echo "Skipping GitHub deletion for ${ENV_TO_DELETE} — GITHUB_TOKEN or GITHUB_REPOSITORY not set."
+        fi
+    else
+        echo "Pantheon environment ${ENV_TO_DELETE} not found."
+    fi
 done

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -69,7 +69,7 @@ fi
 # Go ahead and delete the oldest environments.
 for ENV_TO_DELETE in $OLDEST_ENVIRONMENTS; do
     if terminus env:info "${PANTHEON_SITE}.${ENV_TO_DELETE}" > /dev/null 2>&1; then
-        terminus env:delete "${TERMINUS_SITE}.${ENV_TO_DELETE}" --delete-branch --yes
+        terminus env:delete "${PANTHEON_SITE}.${ENV_TO_DELETE}" --delete-branch --yes
         if [ -n "$GITHUB_REPOSITORY" ]; then
             delete_github_environment "$ENV_TO_DELETE"
         else

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -56,9 +56,9 @@ OLDEST_ENVIRONMENTS=$(echo "$ALL_ENVS" \
   | grep -v dev \
   | grep -v test \
   | grep -v live \
-  | sort \
   | grep "$MULTIDEV_DELETE_PATTERN" \
   | grep -v '^pr-' \
+  | sort \
   | sed -e '$d')
 
 # Exit if there are no environments to delete.

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,29 +1,60 @@
 #!/bin/bash
 set +e
 
-# Delete old multidevs
+# Function to delete a GitHub environment and all of its associated deployments.
+# The GitHub API requires that all deployments be deleted before an environment
+# can be deleted.
+delete_github_environment() {
+  local ENV_NAME=$1
+  echo "Cleaning up GitHub environment: ${ENV_NAME}..."
+
+  # Check if the environment exists before trying to delete it.
+  if ! gh api "repos/${GITHUB_REPOSITORY}/environments/${ENV_NAME}" > /dev/null 2>&1; then
+    echo "GitHub environment ${ENV_NAME} does not exist, skipping deletion."
+    return
+  fi
+
+  # Get the list of deployment IDs for the environment.
+  DEPLOYMENT_IDS=$(gh api "repos/${GITHUB_REPOSITORY}/deployments?environment=${ENV_NAME}" --jq '.[].id')
+
+  if [ -n "$DEPLOYMENT_IDS" ]; then
+    for DEPLOYMENT_ID in $DEPLOYMENT_IDS; do
+      echo "  - Deleting deployment ID ${DEPLOYMENT_ID}..."
+      # Deployments must be inactive before they can be deleted.
+      # The bobheadxi/deployments action should handle this, but we do it here to be safe.
+      gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" -f state='inactive' -f description='Deployment is being deleted.' > /dev/null
+      # Now delete the deployment itself.
+      gh api --method DELETE "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}"
+    done
+  else
+    echo "  - No deployments found for environment ${ENV_NAME}."
+  fi
+
+  # Finally, delete the environment now that it is empty.
+  echo "  - Deleting environment ${ENV_NAME}..."
+  gh api --method DELETE "repos/${GITHUB_REPOSITORY}/environments/${ENV_NAME}"
+}
+
+# Change to the site root if specified.
 if [ -n "$SITE_ROOT" ]; then
   cd "${SITE_ROOT}" || return
 fi
 
-echo "Deleting Pantheon PR multidev environment..."
+echo "Deleting stale Pantheon PR multidev environments..."
+# The `terminus build:env:delete:pr` command will find and delete multidev
+# environments that are associated with closed or merged pull requests.
 terminus build:env:delete:pr "$PANTHEON_SITE" --yes
 
-echo "Deleting GitHub deployment environment: ${PANTHEON_TARGET_ENV}..."
-gh api --method DELETE "repos/${GITHUB_REPOSITORY}/environments/${PANTHEON_TARGET_ENV}" || true
-
-# Only delete old environments if there is a pattern defined to
-# match environments eligible for deletion. Otherwise, delete the
-# current multidev environment immediately.
-#
-# To use this feature, set MULTIDEV_DELETE_PATTERN to 'pr-' or similar
-# in the CI server environment variables.
+# The block below is intended to delete old environments that are not associated
+# with pull requests. This is useful for cleaning up environments created by
+# manual workflows or other automated processes.
 if [ -z "$MULTIDEV_DELETE_PATTERN" ] || [ -z "$DELETE_OLD_MULTIDEVS" ] || [ "$DELETE_OLD_MULTIDEVS" != "true" ]; then
-  echo "No MULTIDEV_DELETE_PATTERN set or delete old multidevs was not set to true. Skipping deletion of old environments..."
+  echo "No MULTIDEV_DELETE_PATTERN set or delete_old_environments was not set to true. Skipping deletion of old environments..."
   exit 0
 fi
 
-# List all but the newest two environments.
+# List all environments, filter out the standard dev/test/live, find the ones
+# that match our deletion pattern, and then exclude the most recent one.
 ALL_ENVS=$(terminus env:list "$TERMINUS_SITE" --format=list)
 OLDEST_ENVIRONMENTS=$(echo "$ALL_ENVS" \
   | grep -v dev \
@@ -33,24 +64,21 @@ OLDEST_ENVIRONMENTS=$(echo "$ALL_ENVS" \
   | grep "$MULTIDEV_DELETE_PATTERN" \
   | sed -e '$d')
 
-# Exit if there are no environments to delete
+# Exit if there are no environments to delete.
 if [ -z "$OLDEST_ENVIRONMENTS" ] ; then
+  echo "No old environments matching the pattern found to delete."
   exit 0
 fi
 
 # Go ahead and delete the oldest environments.
 for ENV_TO_DELETE in $OLDEST_ENVIRONMENTS; do
+  # Delete the Pantheon multidev environment.
   terminus env:delete "${TERMINUS_SITE}.${ENV_TO_DELETE}" --delete-branch --yes
 
-  # Delete related GitHub deployment environment
+  # Delete the related GitHub deployment environment.
   if [ -n "$GITHUB_REPOSITORY" ]; then
-    echo "Deleting GitHub deployment environment: ${ENV_TO_DELETE}..."
-    if ! gh api "repos/${GITHUB_REPOSITORY}/environments/${ENV_TO_DELETE}" > /dev/null 2>&1; then
-      echo "GitHub environment $ENV_TO_DELETE does not exist, skipping deletion."
-      continue
-    fi
-    gh api --method DELETE "repos/${GITHUB_REPOSITORY}/environments/${ENV_TO_DELETE}"
-  else 
+    delete_github_environment "$ENV_TO_DELETE"
+  else
     echo "Skipping GitHub deletion for ${ENV_TO_DELETE} — GITHUB_TOKEN or GITHUB_REPOSITORY not set."
   fi
 done

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -21,7 +21,6 @@ delete_github_environment() {
     for DEPLOYMENT_ID in $DEPLOYMENT_IDS; do
       echo "  - Deleting deployment ID ${DEPLOYMENT_ID}..."
       # Deployments must be inactive before they can be deleted.
-      # The bobheadxi/deployments action should handle this, but we do it here to be safe.
       gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" -f state='inactive' -f description='Deployment is being deleted.' > /dev/null
       # Now delete the deployment itself.
       gh api --method DELETE "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}"
@@ -35,14 +34,20 @@ delete_github_environment() {
   gh api --method DELETE "repos/${GITHUB_REPOSITORY}/environments/${ENV_NAME}"
 }
 
-# Change to the site root if specified.
+# The terminus build:env:delete:pr command relies on the git history to find
+# pull requests. If we are running in a fixture directory, we need to
+# re-initialize git to ensure it points to the correct repository.
 if [ -n "$SITE_ROOT" ]; then
   cd "${SITE_ROOT}" || return
+  echo "Re-initializing git in ${SITE_ROOT} to ensure correct repository context..."
+  rm -rf .git
+  git init -b main >/dev/null 2>&1
+  git remote add origin "https://github.com/${GITHUB_REPOSITORY}" >/dev/null 2>&1
 fi
 
 echo "Deleting stale Pantheon PR multidev environments..."
-# The `terminus build:env:delete:pr` command will find and delete multidev
-# environments that are associated with closed or merged pull requests.
+# This command will find and delete multidev environments that are associated
+# with closed or merged pull requests.
 terminus build:env:delete:pr "$PANTHEON_SITE" --yes
 
 # The block below is intended to delete old environments that are not associated

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -70,7 +70,6 @@ fi
 for ENV_TO_DELETE in $OLDEST_ENVIRONMENTS; do
     echo "Deleting Pantheon environment: ${ENV_TO_DELETE}..."
     if terminus env:info "${PANTHEON_SITE}.${ENV_TO_DELETE}" > /dev/null 2>&1; then
-        echo "Found Pantheon environment ${ENV_TO_DELETE}, proceeding with deletion."
         terminus env:delete "${PANTHEON_SITE}.${ENV_TO_DELETE}" --delete-branch --yes
         if [ -n "$GITHUB_REPOSITORY" ]; then
             delete_github_environment "$ENV_TO_DELETE"


### PR DESCRIPTION
This action currently can clean up Pantheon Multidev environments after a PR has been merged. But it doesn't clean up the GitHub representation of deployed environments. For instance, my own site which consumes this action has over 400 "deployments" to a few dozen different environments.

<img width="212" alt="Screenshot 2025-04-09 at 10 24 40 AM" src="https://github.com/user-attachments/assets/24026d1b-44c6-48bc-845a-f27ab7290299" />

This action should clean those up too. This behavior can be accomplished by using the same 3rd party action that is currently creating the deployments, though it requires the consumer to generate a token with greater permissions (I think) https://github.com/bobheadxi/deployments?tab=readme-ov-file#step-delete-env