### PR TITLE
Use 3.x branch of build tools

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -123,7 +123,7 @@ runs:
 
       - name: Install Terminus Plugin
         shell: bash
-        run: terminus self:plugin:install "pantheon-systems/terminus-build-tools-plugin:dev-3.x"
+        run: terminus self:plugin:install "pantheon-systems/terminus-build-tools-plugin:3.x-dev"
 
       - name: Check Terminus Plugin
         shell: bash

--- a/action.yml
+++ b/action.yml
@@ -123,10 +123,7 @@ runs:
 
       - name: Install Terminus Plugin
         shell: bash
-        run: |
-          # Install Terminus Plugin
-          set +e
-          terminus self:plugin:install "pantheon-systems/terminus-build-tools-plugin:3.x"
+        run: terminus self:plugin:install "pantheon-systems/terminus-build-tools-plugin:3.x"
 
       - name: Configure Git User
         shell: bash

--- a/action.yml
+++ b/action.yml
@@ -130,6 +130,7 @@ runs:
         run: |
           cat ~/.terminus/plugins-3.x/composer.json
           terminus plugin:update
+          terminus plugin:list
 
       - name: Configure Git User
         shell: bash

--- a/action.yml
+++ b/action.yml
@@ -123,7 +123,7 @@ runs:
 
       - name: Install Terminus Plugin
         shell: bash
-        run: terminus self:plugin:install "pantheon-systems/terminus-build-tools-plugin:3.x"
+        run: terminus self:plugin:install "pantheon-systems/terminus-build-tools-plugin:2cbf6b4"
 
       - name: Check Terminus Plugin
         shell: bash

--- a/action.yml
+++ b/action.yml
@@ -123,7 +123,7 @@ runs:
 
       - name: Install Terminus Plugin
         shell: bash
-        run: terminus self:plugin:install "pantheon-systems/terminus-build-tools-plugin:2cbf6b4"
+        run: terminus self:plugin:install "pantheon-systems/terminus-build-tools-plugin:dev-3.x"
 
       - name: Check Terminus Plugin
         shell: bash

--- a/action.yml
+++ b/action.yml
@@ -129,6 +129,7 @@ runs:
         shell: bash
         run: |
           cat ~/.terminus/plugins-3.x/composer.json
+          terminus plugin:update
 
       - name: Configure Git User
         shell: bash

--- a/action.yml
+++ b/action.yml
@@ -125,13 +125,6 @@ runs:
         shell: bash
         run: terminus self:plugin:install "pantheon-systems/terminus-build-tools-plugin:3.x-dev"
 
-      - name: Check Terminus Plugin
-        shell: bash
-        run: |
-          cat ~/.terminus/plugins-3.x/composer.json
-          terminus plugin:update
-          terminus plugin:list
-
       - name: Configure Git User
         shell: bash
         env:

--- a/action.yml
+++ b/action.yml
@@ -125,6 +125,11 @@ runs:
         shell: bash
         run: terminus self:plugin:install "pantheon-systems/terminus-build-tools-plugin:3.x"
 
+      - name: Check Terminus Plugin
+        shell: bash
+        run: |
+          echo cat ~/.terminus/plugins-3.x/composer.json
+
       - name: Configure Git User
         shell: bash
         env:

--- a/action.yml
+++ b/action.yml
@@ -128,7 +128,7 @@ runs:
       - name: Check Terminus Plugin
         shell: bash
         run: |
-          echo cat ~/.terminus/plugins-3.x/composer.json
+          cat ~/.terminus/plugins-3.x/composer.json
 
       - name: Configure Git User
         shell: bash

--- a/action.yml
+++ b/action.yml
@@ -126,7 +126,7 @@ runs:
         run: |
           # Install Terminus Plugin
           set +e
-          terminus self:plugin:install terminus-build-tools-plugin
+          terminus self:plugin:install "pantheon-systems/terminus-build-tools-plugin:3.x"
 
       - name: Configure Git User
         shell: bash


### PR DESCRIPTION
Until a release is cut with https://github.com/pantheon-systems/terminus-build-tools-plugin/pull/453, we need the `3.x` branch of Build Tools.