### PR TITLE
Use the v1 tag of pantheon-systems/terminus-github-actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -117,7 +117,7 @@ runs:
             ssh-private-key: ${{ inputs.ssh_key }}
 
       - name: Install Terminus
-        uses: pantheon-systems/terminus-github-actions@main
+        uses: pantheon-systems/terminus-github-actions@v1
         with:
           pantheon-machine-token: ${{ inputs.machine_token }}
 


### PR DESCRIPTION
Generally, there isn't much advantage to using a branch as the Git ref for referencing a Github action; there's more risk of churn and incompatibilities over time. I think it makes more sense to use a specific commit hash or, barring that, reference a git tag. This switches to using the major v1 version tag for the `pantheon-systems/terminus-github-actions` Github action.