### PR TITLE
Add a description for the github action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,5 @@
 name: Deploy Site to Pantheon
+description: A GitHub Action that pushes code to Pantheon Dev and Multidev environments 
 inputs:
   ssh_key:
     description: 'A private key that corresponds to a public key on Pantheon: https://docs.pantheon.io/ssh-keys'


### PR DESCRIPTION
The action description is required for inclusion in the GitHub Actions Marketplace.
This PR adds the description and is a no-op -- there's no functional code that is changed here.