### PR TITLE
Update deploy workflow trigger paths

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -7,10 +7,10 @@ concurrency:
 on:
   pull_request:
     types: [opened, synchronize]
-  paths:
-    - '.github/testing_fixtures/dtp-nearly-empty-site/**'
-    - 'action.yml'
-    - '.github/workflows/deploy-pr.yml'
+    paths:
+      - '.github/testing_fixtures/dtp-nearly-empty-site/**'
+      - 'action.yml'
+      - '.github/workflows/deploy-pr.yml'
 
 jobs:
   build:

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -7,6 +7,10 @@ concurrency:
 on:
   pull_request:
     types: [opened, synchronize]
+  paths:
+    - '.github/testing_fixtures/dtp-nearly-empty-site/**'
+    - 'action.yml'
+    - '.github/workflows/deploy-pr.yml'
 
 jobs:
   build:


### PR DESCRIPTION
Modify the deploy workflow to trigger only when specific files related to the action or fixture code are modified.

fixes #79