### PR TITLE
Enable deployments from forked pull requests

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -10,7 +10,6 @@ on:
     paths:
       - '.github/testing_fixtures/**'
       - 'action.yml'
-      - '.github/workflows/deploy-pr.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -7,9 +7,13 @@ concurrency:
 on:
   pull_request_target:
     types: [opened, synchronize]
+    paths:
+      - '.github/workflows/deploy-pr.yml'
+      - 'action.yml'
+      - '.github/testing_fixtures/**'
 
 jobs:
-  build:
+  deploy:
     # This job uses `pull_request_target` to gain access to secrets, which
     # are not available on normal `pull_request` events for forks.
     # The two-step checkout process below is critical for security.

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -5,22 +5,34 @@ concurrency:
   cancel-in-progress: false
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
-    paths:
-      - '.github/testing_fixtures/dtp-nearly-empty-site/**'
-      - 'action.yml'
-      - '.github/workflows/deploy-pr.yml'
 
 jobs:
   build:
+    # This job uses `pull_request_target` to gain access to secrets, which
+    # are not available on normal `pull_request` events for forks.
+    # The two-step checkout process below is critical for security.
+    # It ensures that we are executing trusted code from the base repository
+    # while operating on the untrusted code from the pull request.
     permissions:
       deployments: write
-      contents: read
-      pull-requests: read   
+      contents: write # needed to checkout the PR code.
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
+    # Checkout the base repository at the current commit.
+    # This is the trusted code that will be executed.
     - uses: actions/checkout@v4
+
+    # Checkout the pull request code into a subdirectory.
+    # This is the code that will be deployed.
+    - name: Checkout PR code
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
+        path: pr-code
     - name: deploy to Pantheon
       uses: ./
       with:
@@ -28,7 +40,7 @@ jobs:
         machine_token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
         site: dtp-nearly-empty-site
         target_env: "pr-${{ github.event.pull_request.number }}"
-        relative_site_root: ".github/testing_fixtures/dtp-nearly-empty-site"
+        relative_site_root: "pr-code/.github/testing_fixtures/dtp-nearly-empty-site"
         git_user_name: "Test Name"
         git_user_email: "test@example.com"
         git_commit_message: "This is an automated commit message from GitHub Actions."

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -8,9 +8,9 @@ on:
   pull_request_target:
     types: [opened, synchronize]
     paths:
-      - '.github/workflows/deploy-pr.yml'
-      - 'action.yml'
       - '.github/testing_fixtures/**'
+      - 'action.yml'
+      - '.github/workflows/deploy-pr.yml'
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -1,7 +1,7 @@
 name: Deploy PR to Pantheon
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
 on:
@@ -11,9 +11,12 @@ on:
       - '.github/testing_fixtures/**'
       - 'action.yml'
       - '.github/workflows/deploy-pr.yml'
+  workflow_dispatch:
 
 jobs:
-  deploy:
+  deploy_pr:
+    name: Deploy Pull Request
+    if: github.event_name == 'pull_request_target'
     # This job uses `pull_request_target` to gain access to secrets, which
     # are not available on normal `pull_request` events for forks.
     # The two-step checkout process below is critical for security.
@@ -48,5 +51,29 @@ jobs:
         git_user_name: "Test Name"
         git_user_email: "test@example.com"
         git_commit_message: "This is an automated commit message from GitHub Actions."
+        delete_old_environments: true
+        clone_content: true
+
+  test_workflow:
+    name: Test Workflow Manually
+    if: github.event_name == 'workflow_dispatch'
+    permissions:
+      deployments: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+    - name: deploy to Pantheon
+      uses: ./
+      with:
+        ssh_key: ${{ secrets.PANTHEON_SSH_KEY }}
+        machine_token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
+        site: dtp-nearly-empty-site
+        target_env: "test-${{ github.ref_name }}"
+        relative_site_root: ".github/testing_fixtures/dtp-nearly-empty-site"
+        git_user_name: "Test Name"
+        git_user_email: "test@example.com"
+        git_commit_message: "This is a manual test deployment from GitHub Actions."
         delete_old_environments: true
         clone_content: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,3 +7,9 @@
 Cutting a release is a _manual_ process and should be created from the `0.x` branch. This is to ensure that we know exactly what changes are included in the release and when releases are made.
 
 To cut a new release, navigate to the Actions tab and select the "Create Release" workflow. Fill in the required field for the version number, and submit the form. A new Git tag will be created, and the release will be published on GitHub with release notes auto-generated from the merged PRs.
+
+## Testing changes to the Deploy PR to Pantheon workflow
+
+Because we have implemented a `pull_request_target` trigger for the Deploy PR to Pantheon workflow to allow robots to access secrets and run the deployment, and because `pull_request_target` uses the base branch rather than the PR branch, if you want to test changes to the workflow itself, you can do so by using the `workflow_dispatch` trigger. 
+
+To do this, navigate to the Actions tab and select the "Deploy PR to Pantheon" workflow. You can then manually trigger the workflow. This will allow you to test changes to the workflow without needing to create a pull request.

--- a/readme.md
+++ b/readme.md
@@ -194,7 +194,7 @@ That use case can be accommodated by adding additional steps to the workflow bef
 
 Here's an example from a real site that uses Tailwind to prepare CSS in the site's custom theme.
 
-```
+```yml
   push-to-pantheon:
     runs-on: ubuntu-latest
     steps:
@@ -220,7 +220,7 @@ By calling `npm run build` and modifying `gitignore` prior to calling `push-to-p
 
 This action needs permission to perform its work. Set the following permissions either at the level of the workflow or at the level of the job that uses this action.
 
-```
+```yml
     permissions:
       deployments: write
       contents: read
@@ -238,6 +238,49 @@ Even though this action does not checkout of the code itself, the code must be c
 The `pull-requests: read` permission is required to delete old Multidev environments associated with closed pull requests.
 
 [See the GitHub Actions documentation for more information on permissions.](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token)
+
+### Using this action with robots (like Dependabot)
+
+When using this action with robots like [Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependency-updates), it is important to ensure that the workflow has access to the secrets needed to push to Pantheon.
+This is because robots like Dependabot create pull requests from forks of the repository, and GitHub does not allow secrets to be used in workflows triggered by pull requests from forks for security reasons.
+To work around this, you can use the `pull_request_target` event instead of the `pull_request` event combined with a two-step checkout process that ensures that the code being executed is from the base repository, not the fork.
+
+Here is an example of how to set up a workflow that uses this action with Dependabot:
+
+```yml
+name: Deploy PR to Pantheon
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+jobs:
+  push:
+    permissions:
+      deployments: write
+      contents: write # needed to checkout the PR code.
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+    # Checkout the base repository code into the root directory.
+    # This is the code that will be used to run the workflow.
+    - name: Checkout base repository code
+      uses: actions/checkout@v4
+
+    # Checkout the pull request code into a subdirectory.
+    # This is the code that will be deployed.
+    - name: Checkout PR code
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
+        path: pr-code
+    - name: Push to Pantheon
+      uses: pantheon-systems/push-to-pantheon@0.6.1
+      with:
+        ssh_key: ${{ secrets.PANTHEON_SSH_KEY }}
+        machine_token: ${{ secrets.MACHINE_TOKEN }}
+        site: ${{ vars.PANTHEON_SITE }}
+        relative_site_root: pr-code
+```
 
 ### Concurrency
 


### PR DESCRIPTION
Switch to using `pull_request_target` for workflows to allow access to secrets during deployments from forked repositories. Implement a two-step checkout process to enhance security while documenting the setup for Dependabot and similar tools in the README. 

This PR also adds syntax highlighting to two yml code blocks for better readability.

fixes #72