### PR TITLE
Use pull request head SHA for deployment reference

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -15,7 +15,6 @@ on:
 jobs:
   deploy_pr:
     name: Deploy Pull Request
-    if: github.event_name == 'pull_request_target'
     # This job uses `pull_request_target` to gain access to secrets, which
     # are not available on normal `pull_request` events for forks.
     # The two-step checkout process below is critical for security.
@@ -50,29 +49,5 @@ jobs:
         git_user_name: "Test Name"
         git_user_email: "test@example.com"
         git_commit_message: "This is an automated commit message from GitHub Actions."
-        delete_old_environments: true
-        clone_content: true
-
-  test_workflow:
-    name: Test Workflow Manually
-    if: github.event_name == 'workflow_dispatch'
-    permissions:
-      deployments: write
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v4
-    - name: deploy to Pantheon
-      uses: ./
-      with:
-        ssh_key: ${{ secrets.PANTHEON_SSH_KEY }}
-        machine_token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
-        site: dtp-nearly-empty-site
-        target_env: "test-${{ github.ref_name }}"
-        relative_site_root: ".github/testing_fixtures/dtp-nearly-empty-site"
-        git_user_name: "Test Name"
-        git_user_email: "test@example.com"
-        git_commit_message: "This is a manual test deployment from GitHub Actions."
         delete_old_environments: true
         clone_content: true

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -1,0 +1,32 @@
+name: Manual Deploy Branch to Pantheon
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test_workflow:
+    name: Test Workflow Manually
+    permissions:
+      deployments: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+    - name: deploy to Pantheon
+      uses: ./
+      with:
+        ssh_key: ${{ secrets.PANTHEON_SSH_KEY }}
+        machine_token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
+        site: dtp-nearly-empty-site
+        target_env: "test-${{ github.ref_name }}"
+        relative_site_root: ".github/testing_fixtures/dtp-nearly-empty-site"
+        git_user_name: "Test Name"
+        git_user_email: "test@example.com"
+        git_commit_message: "This is a manual test deployment from GitHub Actions."
+        delete_old_environments: true
+        clone_content: true	

--- a/action.yml
+++ b/action.yml
@@ -113,7 +113,7 @@ runs:
           step: start
           token: ${{ github.token }}
           env: ${{ env.PANTHEON_TARGET_ENV }}
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Configure SSH key
         uses: webfactory/ssh-agent@v0.9.1
@@ -185,7 +185,7 @@ runs:
           step: finish
           token: ${{ github.token }}
           status: ${{ job.status }}
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           # todo, how does this work when there is a step above with the id of "deployment" not "deployment_id"
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
           env: ${{ env.PANTHEON_TARGET_ENV }}-${{ inputs.site }}


### PR DESCRIPTION
Switching from `github.head_ref` to `github.event.pull_request.head.sha` ensures that the deployment is accurately linked to the specific commit that triggered the workflow. This change addresses issues with deployment statuses in forked repositories.

Fixes #87