### PR TITLE
use step outputs to control terminus installation

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   test_workflow_no_terminus_install:
     name: Test Deploy without Terminus Install
-    if: ${{ inputs.install_terminus == 'No' }}
+    if: ${{ github.event.inputs.install_terminus == 'No' }}
     permissions:
       deployments: write
       contents: read
@@ -59,7 +59,7 @@ jobs:
         clone_content: true
   test_workflow_with_terminus_install:
     name: Test Deploy with Terminus Install
-    if: ${{ inputs.install_terminus == 'Yes' }}
+    if: ${{ github.event.inputs.install_terminus == 'Yes' }}
     permissions:
         deployments: write
         contents: read

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   test_workflow_no_terminus_install:
     name: Test Deploy without Terminus Install
-    if: ${{ inputs.install_terminus == false }}
+    if: ${{ inputs.install_terminus == 'false' }}
     permissions:
       deployments: write
       contents: read
@@ -56,7 +56,7 @@ jobs:
         clone_content: true
   test_workflow_with_terminus_install:
     name: Test Deploy with Terminus Install
-    if: ${{ inputs.install_terminus == true }}
+    if: ${{ inputs.install_terminus == 'true' }}
     permissions:
         deployments: write
         contents: read

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       install_terminus:
-        description: 'Install Terminus CLI?'
+        description: 'Install Terminus during deploy?'
         required: true
         default: 'Yes'
         type: choice

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -57,6 +57,7 @@ jobs:
         git_user_email: "test@example.com"
         git_commit_message: "This is a manual test deployment from GitHub Actions."
         clone_content: true
+
   test_workflow_with_terminus_install:
     name: Test Deploy with Terminus Install
     if: ${{ github.event.inputs.install_terminus == 'Yes' }}

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -6,10 +6,17 @@ concurrency:
 
 on:
   workflow_dispatch:
+    inputs:
+      install_terminus:
+        description: 'Install Terminus CLI?'
+        required: false
+        default: true
+        type: boolean
 
 jobs:
-  test_workflow:
-    name: Test Workflow Manually
+  test_workflow_no_terminus_install:
+    name: Test Deploy without Terminus Install
+    if: ${{ inputs.install_terminus == false }}
     permissions:
       deployments: write
       contents: read
@@ -47,3 +54,30 @@ jobs:
         git_user_email: "test@example.com"
         git_commit_message: "This is a manual test deployment from GitHub Actions."
         clone_content: true
+  test_workflow_with_terminus_install:
+    name: Test Deploy with Terminus Install
+    if: ${{ inputs.install_terminus == true }}
+    permissions:
+        deployments: write
+        contents: read
+    runs-on: ubuntu-latest
+    steps:
+        - name: Checkout Repository
+          uses: actions/checkout@v4
+
+        - name: Set short branch name
+          id: vars
+          run: echo "short_ref_name=$(echo ${{ github.ref_name }} | sed 's/[^a-zA-Z0-9-]//g' | cut -c1-6)" >> $GITHUB_OUTPUT
+
+        - name: deploy to Pantheon
+          uses: ./
+          with:
+            ssh_key: ${{ secrets.PANTHEON_SSH_KEY }}
+            machine_token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
+            site: dtp-nearly-empty-site
+            target_env: "test-${{ steps.vars.outputs.short_ref_name }}"
+            relative_site_root: ".github/testing_fixtures/dtp-nearly-empty-site"
+            git_user_name: "Test Name"
+            git_user_email: "test@example.com"
+            git_commit_message: "This is a manual test deployment from GitHub Actions."
+            clone_content: true

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -9,14 +9,17 @@ on:
     inputs:
       install_terminus:
         description: 'Install Terminus CLI?'
-        required: false
-        default: true
-        type: boolean
+        required: true
+        default: 'Yes'
+        type: choice
+        options:
+          - 'Yes'
+          - 'No'
 
 jobs:
   test_workflow_no_terminus_install:
     name: Test Deploy without Terminus Install
-    if: ${{ inputs.install_terminus == 'false' }}
+    if: ${{ inputs.install_terminus == 'No' }}
     permissions:
       deployments: write
       contents: read
@@ -56,7 +59,7 @@ jobs:
         clone_content: true
   test_workflow_with_terminus_install:
     name: Test Deploy with Terminus Install
-    if: ${{ inputs.install_terminus == 'true' }}
+    if: ${{ inputs.install_terminus == 'Yes' }}
     permissions:
         deployments: write
         contents: read

--- a/action.yml
+++ b/action.yml
@@ -130,18 +130,17 @@ runs:
         if: ${{ inputs.skip_terminus_install == false }}
         id: check_terminus
         shell: bash
-        continue-on-error: true
         run: |
-          if ! command -v terminus &> /dev/null; then
-            echo "Terminus not installed, proceeding to install."
-            exit 1
-          else
+          if command -v terminus &> /dev/null; then
             echo "Terminus detected. Skipping Terminus installation."
-            exit 0
+            echo "should_install_terminus=false" >> $GITHUB_OUTPUT
+          else
+            echo "Terminus not installed, proceeding to install."
+            echo "should_install_terminus=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Install Terminus
-        if: ${{ inputs.skip_terminus_install != 'true' && steps.check_terminus.outcome == 'failure' }}
+        if: ${{ inputs.skip_terminus_install == false && steps.check_terminus.outputs.should_install_terminus == 'true' }}
         uses: pantheon-systems/terminus-github-actions@v1
         with:
           pantheon-machine-token: ${{ inputs.machine_token }}

--- a/action.yml
+++ b/action.yml
@@ -127,7 +127,7 @@ runs:
             ssh-private-key: ${{ inputs.ssh_key }}
 
       - name: Check for Terminus
-        if: ${{ inputs.skip_terminus_install == false }}
+        if: ${{ inputs.skip_terminus_install !== 'true' }}
         id: check_terminus
         shell: bash
         run: |
@@ -140,7 +140,7 @@ runs:
           fi
 
       - name: Install Terminus
-        if: ${{ inputs.skip_terminus_install == false && steps.check_terminus.outputs.should_install_terminus == 'true' }}
+        if: ${{ inputs.skip_terminus_install !== 'true' && steps.check_terminus.outputs.should_install_terminus == 'true' }}
         uses: pantheon-systems/terminus-github-actions@v1
         with:
           pantheon-machine-token: ${{ inputs.machine_token }}

--- a/action.yml
+++ b/action.yml
@@ -127,7 +127,7 @@ runs:
             ssh-private-key: ${{ inputs.ssh_key }}
 
       - name: Check for Terminus
-        if: ${{ inputs.skip_terminus_install !== 'true' }}
+        if: ${{ inputs.skip_terminus_install != 'true' }}
         id: check_terminus
         shell: bash
         run: |
@@ -140,7 +140,7 @@ runs:
           fi
 
       - name: Install Terminus
-        if: ${{ inputs.skip_terminus_install !== 'true' && steps.check_terminus.outputs.should_install_terminus == 'true' }}
+        if: ${{ inputs.skip_terminus_install != 'true' && steps.check_terminus.outputs.should_install_terminus == 'true' }}
         uses: pantheon-systems/terminus-github-actions@v1
         with:
           pantheon-machine-token: ${{ inputs.machine_token }}


### PR DESCRIPTION
The previous method for checking if Terminus was installed relied on the step failing (`continue-on-error: true`) and then checking the step's `outcome`. This approach would actually bail out on the error code, causing Terminus to not be installed at all and the deploy to fail.

This change refactors the logic to use step outputs. The check step now sets an output variable (`should_install_terminus`) which is then cleanly evaluated in the `if` condition of the installation step. This makes the workflow logic clearer and avoids misleading failure statuses in the action's run log.

The PR also adds an input to the manual `workflow_dispatch` trigger to manually test deploys. Previously, because we wanted to test if the workflow worked as expected when Terminus was already installed, the manual workflow would _only_ pre-install Terminus as part of the workflow before running `push-to-pantheon`. This change makes this an option that can be toggled when the workflow dispatch is triggered, so the user (e.g. an administrator or developer with owner rights testing the branch) can choose whether to test the terminus install step or not.

fixes #93 