### PR TITLE
Release management updates

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,7 +1,6 @@
 name: Create Release
 
 on:
-  # Allows manual triggering of the workflow from the Actions tab
   workflow_dispatch:
     inputs:
       version:
@@ -14,7 +13,6 @@ jobs:
     name: 'Release Push to Pantheon update'
     runs-on: ubuntu-latest
     permissions:
-      # Required for checking out the code, committing, and creating a release
       contents: write
       
     steps:
@@ -32,14 +30,17 @@ jobs:
           echo "previous_version=$PREVIOUS_VERSION" >> $GITHUB_OUTPUT
         shell: bash
 
-      - name: Update version in README.md
+      - name: Check versions in README.md
         run: |
-          # Escape dots in the previous version to ensure they are treated as literal characters in the sed regex.
+          # If the previous version is found in the README.md, exit with an error.
           PREVIOUS_VERSION_ESCAPED=$(echo "${{ steps.get_version.outputs.previous_version }}" | sed 's/\./\\./g')
-          NEW_VERSION="${{ github.event.inputs.version }}"
-
-          # Use the escaped version for a safe replacement.
-          sed -i "s/$PREVIOUS_VERSION_ESCAPED/$NEW_VERSION/g" readme.md
+          if grep -q "$PREVIOUS_VERSION_ESCAPED" readme.md; then
+            echo "Error: Previous version '${{ steps.get_version.outputs.previous_version }}' found in README.md"
+            echo "Run the 'Prepare Release' workflow to update the version first."
+            exit 1
+          fi
+          # Output the new version for further steps.
+          echo "new_version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Configure Git
@@ -48,36 +49,13 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
         shell: bash
 
-      - name: Commit version update
-        id: commit
-        run: |
-          git add readme.md
-          if ! git diff --staged --quiet; then
-            echo "changes_committed=true" >> $GITHUB_OUTPUT
-            git commit -m "docs: Bump version to ${{ github.event.inputs.version }}"
-            echo "commit_hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-            echo "New commit created."
-          else
-            echo "changes_committed=false" >> $GITHUB_OUTPUT
-            echo "No changes to commit."
-          fi
-        shell: bash
-
-      - name: Push commit
-        if: steps.commit.outputs.changes_committed == 'true'
-        run: |
-          git push
-        shell: bash
-
       - name: Create and push Git tag
-        if: steps.commit.outputs.changes_committed == 'true'
         run: |
-          git tag ${{ github.event.inputs.version }} ${{ steps.commit.outputs.commit_hash }}
+          git tag ${{ github.event.inputs.version }}
           git push origin ${{ github.event.inputs.version }}
         shell: bash
 
       - name: Create GitHub Release
-        if: steps.commit.outputs.changes_committed == 'true'
         env:
           # The GITHUB_TOKEN is automatically provided by GitHub
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,64 @@
+name: Prepare Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version to release (e.g., v1.2.3)'
+        required: true
+        type: string
+
+jobs:
+  release:
+    name: 'Prepare Push to Pantheon release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # We need to fetch all history and tags to correctly determine the previous version
+          fetch-depth: 0
+
+      - name: Get previous version tag
+        id: get_version
+        run: |
+          # Get the latest tag from the repository
+          PREVIOUS_VERSION=$(git describe --tags --abbrev=0)
+          echo "previous_version=$PREVIOUS_VERSION" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Update version in README.md
+        run: |
+          # Escape dots in the previous version to ensure they are treated as literal characters in the sed regex.
+          PREVIOUS_VERSION_ESCAPED=$(echo "${{ steps.get_version.outputs.previous_version }}" | sed 's/\./\\./g')
+          NEW_VERSION="${{ github.event.inputs.version }}"
+
+          # Use the escaped version for a safe replacement.
+          sed -i "s/$PREVIOUS_VERSION_ESCAPED/$NEW_VERSION/g" readme.md
+        shell: bash
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+        shell: bash
+
+      - name: Create release PR
+        id: commit
+        run: |
+          git checkout -b release-${{ github.event.inputs.version }}
+          git add readme.md
+          if ! git diff --staged --quiet; then
+            echo "changes_committed=true" >> $GITHUB_OUTPUT
+            git commit -m "docs: Bump version to ${{ github.event.inputs.version }}"
+            echo "commit_hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+            echo "New commit created."
+          else
+            echo "changes_committed=false" >> $GITHUB_OUTPUT
+            echo "No changes to commit."
+          fi
+          git push --set-upstream origin release-${{ github.event.inputs.version }}
+          gh pr create --base main --head release-${{ github.event.inputs.version }} --title "Release ${{ github.event.inputs.version }}" --body "Release ${{ github.event.inputs.version }}"
+        shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,15 @@
 
 Cutting a release is a _manual_ process and should be created from the `0.x` branch. This is to ensure that we know exactly what changes are included in the release and when releases are made.
 
-To cut a new release, navigate to the Actions tab and select the "Create Release" workflow. Fill in the required field for the version number, and submit the form. A new Git tag will be created, and the release will be published on GitHub with release notes auto-generated from the merged PRs.
+### Prepare first
+Before cutting a release, we must first _prepare_ the release. Currently, preparing the release simply creates a GitHub Pull Request that updates the version number in the `readme.md` file to bump the examples to the latest version. 
+
+To prepare a release, navigate to the Actions tab and select the pinned "Prepare Release" workflow. Fill in the required field for the new version number, and submit the form. This will create a pull request that updates the version number in the `readme.md` file.
+
+Once this pull request is approved and merged, a new release can be cut.
+
+### Create the release
+To cut a new release, navigate to the Actions tab and select the pinned "Create Release" workflow. Fill in the required field for the version number, and submit the form. This workflow will check the `readme.md` file for the new version number. If the last release version is still referenced in the `readme.md` file, the workflow will fail. If the last release version is not found, a new Git tag will be created, and the release will be published on GitHub with release notes auto-generated from the merged PRs.
 
 ## Testing changes to the Deploy PR to Pantheon workflow
 


### PR DESCRIPTION
This PR breaks the release step into two.

Since we want to require PRs and PR approvals before merging, we need a PR for readme updates. This necessitates having a two-step prepare-and-release process. This PR breaks the release process in half and creates a PR with the docs/readme changes to merge immediately before a release. additionally, the release workflow is updated to ensure that the prepare step was run first.