### PR TITLE
Check for `origin` before adding it as a remote and allow Build Tools to be bypassed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,11 @@ inputs:
     default: false
     type: boolean
 
+  skip_build_tools:
+    required: false
+    default: false
+    type: boolean
+
   # todo checkout_repo:
   #   description: "A boolean for whether or not this composite step should checkout the git repo. Set to false if a checkout has already been perf"
 
@@ -200,6 +205,7 @@ runs:
           SITE_ROOT: ${{ inputs.relative_site_root }}
           PANTHEON_COMMIT_MESSAGE: ${{ inputs.git_commit_message }}
           GITHUB_TOKEN: ${{ github.token }}
+          SKIP_BUILD_TOOLS: ${{ inputs.skip_build_tools }}
           # todo, might need to make this configurable too.
           # the default in build tools is 180. But that's regularly failing
           # on a small personal site.
@@ -210,6 +216,21 @@ runs:
 
           if [ -n "$SITE_ROOT" ]; then
             cd ${SITE_ROOT}
+          fi
+
+          if [ "$SKIP_BUILD_TOOLS" == "true" ]; then
+            # Check if a multidev already exists for this PR.
+            if terminus multidev:list ${PANTHEON_SITE} --format=list | grep -q "^${PANTHEON_TARGET_ENV}$"; then
+              echo "Multidev environment ${PANTHEON_TARGET_ENV} already exists. Pushing code to existing environment."
+            else
+              echo "Creating new multidev environment: ${PANTHEON_TARGET_ENV}"
+              terminus multidev:create ${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV} ${PANTHEON_TARGET_ENV} --yes
+            fi
+
+            # Push code to Pantheon
+            git remote add pantheon ssh://codeserver.dev.${PANTHEON_SITE}@codeserver.dev.${PANTHEON_SITE}.drush.in:2222/~/repository.git
+            git push pantheon HEAD:refs/heads/${PANTHEON_TARGET_ENV} --force
+            exit 0
           fi
 
           terminus -n build:env:create ${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV} ${PANTHEON_TARGET_ENV} --yes --message="${PANTHEON_COMMIT_MESSAGE}" ${PANTHEON_CLONE_CONTENT_FLAG}

--- a/action.yml
+++ b/action.yml
@@ -133,10 +133,12 @@ runs:
 
       - name: Set up host keys for Pantheon
         shell: bash
+        env:
+          SSH_KEY: ${{ inputs.ssh_key }}
         run: |
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
-          echo "${{ inputs.ssh_key }}" > ~/.ssh/id_rsa
+          printf "%s" "$SSH_KEY" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa        
           echo "Host *.pantheon.io *.drush.in *.getpantheon.com *.panth.io" >> "$HOME/.ssh/config"
           echo "StrictHostKeyChecking no" >> "$HOME/.ssh/config"

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,7 @@ inputs:
     type: boolean
 
   skip_build_tools:
+    description: "If set to true, the action will skip the installation of the Terminus Build Tools plugin and will not use it to create Multidev environments or push code. This is useful if you just want to push the code and are not interested in syncing the database and files as part of your deploy process. By default, the action will install and use the Build Tools plugin unless this is set to true."
     required: false
     default: false
     type: boolean

--- a/action.yml
+++ b/action.yml
@@ -132,6 +132,7 @@ runs:
             ssh-private-key: ${{ inputs.ssh_key }}
 
       - name: Set up host keys for Pantheon
+        shell: bash
         run: |
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh

--- a/action.yml
+++ b/action.yml
@@ -152,6 +152,7 @@ runs:
 
       - name: Install Terminus Plugin
         shell: bash
+        if: ${{ inputs.skip_build_tools != 'true' }}
         run: terminus self:plugin:install "pantheon-systems/terminus-build-tools-plugin:3.x-dev"
 
       - name: Configure Git User

--- a/action.yml
+++ b/action.yml
@@ -131,6 +131,16 @@ runs:
         with:
             ssh-private-key: ${{ inputs.ssh_key }}
 
+      - name: Set up host keys for Pantheon
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          echo "${{ inputs.ssh_key }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa        
+          echo "Host *.pantheon.io *.drush.in *.getpantheon.com *.panth.io" >> "$HOME/.ssh/config"
+          echo "StrictHostKeyChecking no" >> "$HOME/.ssh/config"
+          echo "HostKeyAlgorithms +ssh-rsa" >> "$HOME/.ssh/config"
+
       - name: Check for Terminus
         if: ${{ inputs.skip_terminus_install != 'true' }}
         id: check_terminus
@@ -230,8 +240,6 @@ runs:
             fi
 
             # Push code to Pantheon
-            mkdir -p ~/.ssh
-            ssh-keyscan -p 2222 codeserver.dev.${SITE_ID}.drush.in >> ~/.ssh/known_hosts
             git remote add pantheon ssh://codeserver.dev.${SITE_ID}@codeserver.dev.${SITE_ID}.drush.in:2222/~/repository.git
             git push pantheon HEAD:refs/heads/${PANTHEON_TARGET_ENV} --force
             exit 0

--- a/action.yml
+++ b/action.yml
@@ -172,9 +172,21 @@ runs:
             git init -b main
             git add .
             git commit -m "Initial commit for deployment"
-            git remote -v
+            # Check if remote 'origin' exists and if it's already set to a https://github.com origin. If it is, skip adding it again.
             echo "this origin setting is a hack to get past the 'inferring' of a git provider in build tools"
-            git remote add origin https://github.com/${{ github.repository }}
+            if git remote | grep origin; then
+              ORIGIN_URL=$(git remote get-url origin)
+              if [[ "$ORIGIN_URL" == https://github.com/* ]]; then
+                echo "Remote 'origin' already set to a GitHub URL. Skipping adding origin."
+              else
+                echo "Remote 'origin' exists but is not a GitHub URL. Updating origin to GitHub URL."
+                git remote remove origin
+                git remote add origin https://github.com/${{ github.repository }}
+              fi
+            else
+              echo "Remote 'origin' does not exist. Adding origin to GitHub URL."
+              git remote add origin https://github.com/${{ github.repository }}
+            fi
           else
             git fetch --unshallow origin
           fi

--- a/action.yml
+++ b/action.yml
@@ -230,6 +230,8 @@ runs:
             fi
 
             # Push code to Pantheon
+            mkdir -p ~/.ssh
+            ssh-keyscan -p 2222 codeserver.dev.${SITE_ID}.drush.in >> ~/.ssh/known_hosts
             git remote add pantheon ssh://codeserver.dev.${SITE_ID}@codeserver.dev.${SITE_ID}.drush.in:2222/~/repository.git
             git push pantheon HEAD:refs/heads/${PANTHEON_TARGET_ENV} --force
             exit 0

--- a/action.yml
+++ b/action.yml
@@ -220,6 +220,7 @@ runs:
           fi
 
           if [ "$SKIP_BUILD_TOOLS" == "true" ]; then
+            SITE_ID=$(terminus site:info ${PANTHEON_SITE} --field=id)
             # Check if a multidev already exists for this PR.
             if terminus multidev:list ${PANTHEON_SITE} --format=list | grep -q "^${PANTHEON_TARGET_ENV}$"; then
               echo "Multidev environment ${PANTHEON_TARGET_ENV} already exists. Pushing code to existing environment."
@@ -229,7 +230,7 @@ runs:
             fi
 
             # Push code to Pantheon
-            git remote add pantheon ssh://codeserver.dev.${PANTHEON_SITE}@codeserver.dev.${PANTHEON_SITE}.drush.in:2222/~/repository.git
+            git remote add pantheon ssh://codeserver.dev.${SITE_ID}@codeserver.dev.${SITE_ID}.drush.in:2222/~/repository.git
             git push pantheon HEAD:refs/heads/${PANTHEON_TARGET_ENV} --force
             exit 0
           fi

--- a/action.yml
+++ b/action.yml
@@ -172,6 +172,7 @@ runs:
             git init -b main
             git add .
             git commit -m "Initial commit for deployment"
+            git remote -v
             echo "this origin setting is a hack to get past the 'inferring' of a git provider in build tools"
             git remote add origin https://github.com/${{ github.repository }}
           else

--- a/action.yml
+++ b/action.yml
@@ -240,6 +240,12 @@ runs:
               terminus multidev:create ${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV} ${PANTHEON_TARGET_ENV} --yes
             fi
 
+            # Ensure repo is not shallow; Pantheon rejects shallow pushes
+            if git rev-parse --is-shallow-repository >/dev/null 2>&1 && [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+              echo "Repository is shallow; unshallowing before push."
+              git fetch --unshallow origin || git fetch --depth=1000000 origin
+            fi
+
             # Push code to Pantheon
             git remote add pantheon ssh://codeserver.dev.${SITE_ID}@codeserver.dev.${SITE_ID}.drush.in:2222/~/repository.git
             git push pantheon HEAD:refs/heads/${PANTHEON_TARGET_ENV} --force

--- a/readme.md
+++ b/readme.md
@@ -166,6 +166,14 @@ If set to true, the action will skip installing Terminus. This is useful if you 
    type: boolean
 ```
 
+#### `skip_build_tools`
+If set to true, the action will skip the installation of the Terminus Build Tools plugin and will not use it to create Multidev environments or push code. This is useful if you _just_ want to push the code and are not interested in syncing the database and files as part of your deploy process.
+
+```yml
+   default: false
+   type: boolean
+```
+
 ## Additional recommendations
 
 ### Pin exact version of this action prior to the release of version 1.0.0


### PR DESCRIPTION
This PR accomplishes two things that were failing in at least one (but possibly multiple) instance(s) of the action on sites where I'm running it.

1. Check for, and do not define if already set, an existing `origin` remote pointed to GitHub
2. Allow Build Tools to be bypassed

## Checking for `origin`
I discovered an actual bug that relates to the build tools pipeline in _some_ installations (see this PR: https://github.com/jazzsequence/fair-repo/pull/23).

The point at which the workflow is failing is when it's trying to _add_ the GitHub remote as `origin`, but it can't, because `origin` is already defined (as GitHub). 

This PR adds a check to see if `origin` is already defined, and if it is, checks to see if the `origin` is GitHub. If it's already set up, it bypasses adding the GitHub origin, otherwise, it adds it as normal.

## Bypassing Build Tools
We've gotten a couple requests for this (see #110), but after solving the above issue, my deploys were [still failing](https://github.com/jazzsequence/fair-repo/actions/runs/20249442457/job/58137970922). This turned out to be because of an error in my codebase. An error I could not correct with failing deploys that didn't allow me to push a fix. Of particular note is the fact that the Build Tools-based deploy _copies the database and files_ to the multidev. In this case, all I wanted to do was to push code.

Currently, _one does not simply push code_ with the Push to Pantheon action.
<img width="651" height="383" alt="image" src="https://github.com/user-attachments/assets/a5e2f435-bba6-471f-95c8-fc32f114f87f" />

The longer issue here is in how multidevs are spun up with Build Tools. Specifically, you cannot create a multidev with Build Tools without _at least_ copying the database. Because the database copy (in WordPress) uses WP-CLI, and because WP-CLI boots up WordPress for most of it's commands, if there is a PHP error in the site, the WP-CLI-based database import will (also) error, and the multidev creation process will fail, leaving a multidev _in existence_ but without the site fully set up and in a weird state.

By allowing Build Tools to be bypassed, I can solve the issue and _just_ push the code. This is useful if I want my PR workflow to push to an empty environment rather than one that's already installed, or if I'm syncing my dev environment with Live _manually_ rather than automatically. 

The code here checks the `skip_build_tools` flag and if it's set, proceeds to a workflow that _does not use_ Build Tools at all. It gets the site ID from `terminus site:info` and uses that to construct the Git url. It then checks the environment and if an environment already exists (e.g. multidev or dev) it pushes code to that, otherwise it uses `terminus multidev:create` to create it. Finally, it does a simple `git push pantheon` and exits before we get to the Build Tools command. 

Additionally, the `Install Terminus Plugin` step that installs Build Tools _only runs_ if the `skip_build_tools` flag is not set to `true`.

The default is _to continue_ to use Build Tools but allowing it to be circumvented creates a simpler path that's potentially (slightly) faster as a side effect and doesn't create an inescapable blocker if the codebase is in a weird state.

Fixes #114 