### PR TITLE
Check for live environment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -211,6 +211,25 @@ runs:
             git fetch --unshallow origin
           fi
 
+      - name: Check live environment
+        if: ${{ inputs.skip_build_tools != 'true' }}
+        shell: bash
+        id: check_live_env
+        env:
+          PANTHEON_SITE: ${{ inputs.site }}
+        run: |
+          # Check if live environment exists
+          set +e
+          LIVE_INITIALIZED=$(terminus env:info ${PANTHEON_SITE}.live --field=initialized)
+          if [ "$LIVE_INITIALIZED" == "1" ]; then
+            echo "Live environment exists and is initialized."
+            echo "live_env_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Live environment is not initialized."
+            echo "[alert] Workflow will proceed without Build Tools operations that depend on live environment. You will need to clone content manually to the multidev if required."
+            echo "live_env_exists=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Deployment Processing
         shell: bash
         id: deploy_to_pantheon
@@ -233,7 +252,7 @@ runs:
             cd ${SITE_ROOT}
           fi
 
-          if [ "$SKIP_BUILD_TOOLS" == "true" ]; then
+          if [ "$SKIP_BUILD_TOOLS" == "true" ] || [ "${{ steps.check_live_env.outputs.live_env_exists }}" == "false" ]; then
             SITE_ID=$(terminus site:info ${PANTHEON_SITE} --field=id)
             # Check if a multidev already exists for this PR.
             if terminus multidev:list ${PANTHEON_SITE} --format=list | grep -q "^${PANTHEON_TARGET_ENV}$"; then

--- a/action.yml
+++ b/action.yml
@@ -314,6 +314,7 @@ runs:
           PANTHEON_COMMIT_MESSAGE: ${{ inputs.git_commit_message }}
           GITHUB_TOKEN: ${{ github.token }}
           SKIP_BUILD_TOOLS: ${{ inputs.skip_build_tools }}
+          LIVE_ENV_EXISTS: ${{ steps.check_live_env.outputs.live_env_exists }}
           # todo, might need to make this configurable too.
           # the default in build tools is 180. But that's regularly failing
           # on a small personal site.
@@ -326,7 +327,7 @@ runs:
             cd ${SITE_ROOT}
           fi
 
-          if [ "$SKIP_BUILD_TOOLS" == "true" ] || [ "${{ steps.check_live_env.outputs.live_env_exists }}" == "false" ]; then
+          if [ "$SKIP_BUILD_TOOLS" == "true" ] || [ "$LIVE_ENV_EXISTS" == "false" ]; then
             SITE_ID=$(terminus site:info ${PANTHEON_SITE} --field=id)
             # Check if a multidev already exists for this PR.
             if terminus multidev:list ${PANTHEON_SITE} --format=list | grep -q "^${PANTHEON_TARGET_ENV}$"; then

--- a/action.yml
+++ b/action.yml
@@ -164,9 +164,28 @@ runs:
         with:
           pantheon-machine-token: ${{ inputs.machine_token }}
 
+      - name: Check live environment
+        if: ${{ inputs.skip_build_tools != 'true' }}
+        shell: bash
+        id: check_live_env
+        env:
+          PANTHEON_SITE: ${{ inputs.site }}
+        run: |
+          # Check if live environment exists
+          set +e
+          LIVE_INITIALIZED=$(terminus env:info ${PANTHEON_SITE}.live --field=initialized)
+          if [ "$LIVE_INITIALIZED" == "1" ]; then
+            echo "Live environment exists and is initialized."
+            echo "live_env_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Live environment is not initialized."
+            echo "[alert] Workflow will proceed without Build Tools operations that depend on live environment. You will need to clone content manually to the multidev if required."
+            echo "live_env_exists=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Install Terminus Plugin
         shell: bash
-        if: ${{ inputs.skip_build_tools != 'true' }}
+        if: ${{ inputs.skip_build_tools != 'true' }} && ${{ steps.check_live_env.outputs.live_env_exists == 'true' }}
         run: terminus self:plugin:install "pantheon-systems/terminus-build-tools-plugin:3.x-dev"
 
       - name: Configure Git User
@@ -211,24 +230,6 @@ runs:
             git fetch --unshallow origin
           fi
 
-      - name: Check live environment
-        if: ${{ inputs.skip_build_tools != 'true' }}
-        shell: bash
-        id: check_live_env
-        env:
-          PANTHEON_SITE: ${{ inputs.site }}
-        run: |
-          # Check if live environment exists
-          set +e
-          LIVE_INITIALIZED=$(terminus env:info ${PANTHEON_SITE}.live --field=initialized)
-          if [ "$LIVE_INITIALIZED" == "1" ]; then
-            echo "Live environment exists and is initialized."
-            echo "live_env_exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "Live environment is not initialized."
-            echo "[alert] Workflow will proceed without Build Tools operations that depend on live environment. You will need to clone content manually to the multidev if required."
-            echo "live_env_exists=false" >> $GITHUB_OUTPUT
-          fi
 
       - name: Deployment Processing
         shell: bash

--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,11 @@ inputs:
     default: false
     type: boolean
 
+  skip_build_tools:
+    required: false
+    default: false
+    type: boolean
+
   # todo checkout_repo:
   #   description: "A boolean for whether or not this composite step should checkout the git repo. Set to false if a checkout has already been perf"
 
@@ -200,6 +205,7 @@ runs:
           SITE_ROOT: ${{ inputs.relative_site_root }}
           PANTHEON_COMMIT_MESSAGE: ${{ inputs.git_commit_message }}
           GITHUB_TOKEN: ${{ github.token }}
+          SKIP_BUILD_TOOLS: ${{ inputs.skip_build_tools }}
           # todo, might need to make this configurable too.
           # the default in build tools is 180. But that's regularly failing
           # on a small personal site.
@@ -210,6 +216,21 @@ runs:
 
           if [ -n "$SITE_ROOT" ]; then
             cd ${SITE_ROOT}
+          fi
+
+          if [ "$SKIP_BUILD_TOOLS" == "true" ]; then
+            # Check if a multidev already exists for this PR.
+            if terminus multidev:list ${PANTHEON_SITE} --format=list | grep -q "^${PANTHEON_TARGET_ENV}$"; then
+              echo "Multidev environment ${PANTHEON_TARGET_ENV} already exists. Pushing code to existing environment."
+            else
+              echo "Creating new multidev environment: ${PANTHEON_TARGET_ENV}"
+              terminus multidev:create ${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV} ${PANTHEON_TARGET_ENV} --yes
+            fi
+
+            # Push code to Pantheon
+            git remote add pantheon ssh://codeserver.dev.${PANTHEON_SITE}@codeserver.dev.${PANTHEON_SITE}.drush.in:2222/~/repository.git
+            git push pantheon HEAD:refs/heads/${PANTHEON_TARGET_ENV} --force
+            exit 0
           fi
 
           terminus -n build:env:create ${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV} ${PANTHEON_TARGET_ENV} --yes --message="${PANTHEON_COMMIT_MESSAGE}" ${PANTHEON_CLONE_CONTENT_FLAG}

--- a/action.yml
+++ b/action.yml
@@ -133,10 +133,12 @@ runs:
 
       - name: Set up host keys for Pantheon
         shell: bash
+        env:
+          SSH_KEY: ${{ inputs.ssh_key }}
         run: |
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
-          echo "${{ inputs.ssh_key }}" > ~/.ssh/id_rsa
+          printf "%s" "$SSH_KEY" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa        
           echo "Host *.pantheon.io *.drush.in *.getpantheon.com *.panth.io" >> "$HOME/.ssh/config"
           echo "StrictHostKeyChecking no" >> "$HOME/.ssh/config"

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,7 @@ inputs:
     type: boolean
 
   skip_build_tools:
+    description: "If set to true, the action will skip the installation of the Terminus Build Tools plugin and will not use it to create Multidev environments or push code. This is useful if you just want to push the code and are not interested in syncing the database and files as part of your deploy process. By default, the action will install and use the Build Tools plugin unless this is set to true."
     required: false
     default: false
     type: boolean

--- a/action.yml
+++ b/action.yml
@@ -132,6 +132,7 @@ runs:
             ssh-private-key: ${{ inputs.ssh_key }}
 
       - name: Set up host keys for Pantheon
+        shell: bash
         run: |
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh

--- a/action.yml
+++ b/action.yml
@@ -152,6 +152,7 @@ runs:
 
       - name: Install Terminus Plugin
         shell: bash
+        if: ${{ inputs.skip_build_tools != 'true' }}
         run: terminus self:plugin:install "pantheon-systems/terminus-build-tools-plugin:3.x-dev"
 
       - name: Configure Git User

--- a/action.yml
+++ b/action.yml
@@ -131,6 +131,16 @@ runs:
         with:
             ssh-private-key: ${{ inputs.ssh_key }}
 
+      - name: Set up host keys for Pantheon
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          echo "${{ inputs.ssh_key }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa        
+          echo "Host *.pantheon.io *.drush.in *.getpantheon.com *.panth.io" >> "$HOME/.ssh/config"
+          echo "StrictHostKeyChecking no" >> "$HOME/.ssh/config"
+          echo "HostKeyAlgorithms +ssh-rsa" >> "$HOME/.ssh/config"
+
       - name: Check for Terminus
         if: ${{ inputs.skip_terminus_install != 'true' }}
         id: check_terminus
@@ -230,8 +240,6 @@ runs:
             fi
 
             # Push code to Pantheon
-            mkdir -p ~/.ssh
-            ssh-keyscan -p 2222 codeserver.dev.${SITE_ID}.drush.in >> ~/.ssh/known_hosts
             git remote add pantheon ssh://codeserver.dev.${SITE_ID}@codeserver.dev.${SITE_ID}.drush.in:2222/~/repository.git
             git push pantheon HEAD:refs/heads/${PANTHEON_TARGET_ENV} --force
             exit 0

--- a/action.yml
+++ b/action.yml
@@ -172,9 +172,21 @@ runs:
             git init -b main
             git add .
             git commit -m "Initial commit for deployment"
-            git remote -v
+            # Check if remote 'origin' exists and if it's already set to a https://github.com origin. If it is, skip adding it again.
             echo "this origin setting is a hack to get past the 'inferring' of a git provider in build tools"
-            git remote add origin https://github.com/${{ github.repository }}
+            if git remote | grep origin; then
+              ORIGIN_URL=$(git remote get-url origin)
+              if [[ "$ORIGIN_URL" == https://github.com/* ]]; then
+                echo "Remote 'origin' already set to a GitHub URL. Skipping adding origin."
+              else
+                echo "Remote 'origin' exists but is not a GitHub URL. Updating origin to GitHub URL."
+                git remote remove origin
+                git remote add origin https://github.com/${{ github.repository }}
+              fi
+            else
+              echo "Remote 'origin' does not exist. Adding origin to GitHub URL."
+              git remote add origin https://github.com/${{ github.repository }}
+            fi
           else
             git fetch --unshallow origin
           fi

--- a/action.yml
+++ b/action.yml
@@ -230,6 +230,8 @@ runs:
             fi
 
             # Push code to Pantheon
+            mkdir -p ~/.ssh
+            ssh-keyscan -p 2222 codeserver.dev.${SITE_ID}.drush.in >> ~/.ssh/known_hosts
             git remote add pantheon ssh://codeserver.dev.${SITE_ID}@codeserver.dev.${SITE_ID}.drush.in:2222/~/repository.git
             git push pantheon HEAD:refs/heads/${PANTHEON_TARGET_ENV} --force
             exit 0

--- a/action.yml
+++ b/action.yml
@@ -220,6 +220,7 @@ runs:
           fi
 
           if [ "$SKIP_BUILD_TOOLS" == "true" ]; then
+            SITE_ID=$(terminus site:info ${PANTHEON_SITE} --field=id)
             # Check if a multidev already exists for this PR.
             if terminus multidev:list ${PANTHEON_SITE} --format=list | grep -q "^${PANTHEON_TARGET_ENV}$"; then
               echo "Multidev environment ${PANTHEON_TARGET_ENV} already exists. Pushing code to existing environment."
@@ -229,7 +230,7 @@ runs:
             fi
 
             # Push code to Pantheon
-            git remote add pantheon ssh://codeserver.dev.${PANTHEON_SITE}@codeserver.dev.${PANTHEON_SITE}.drush.in:2222/~/repository.git
+            git remote add pantheon ssh://codeserver.dev.${SITE_ID}@codeserver.dev.${SITE_ID}.drush.in:2222/~/repository.git
             git push pantheon HEAD:refs/heads/${PANTHEON_TARGET_ENV} --force
             exit 0
           fi

--- a/action.yml
+++ b/action.yml
@@ -172,6 +172,7 @@ runs:
             git init -b main
             git add .
             git commit -m "Initial commit for deployment"
+            git remote -v
             echo "this origin setting is a hack to get past the 'inferring' of a git provider in build tools"
             git remote add origin https://github.com/${{ github.repository }}
           else

--- a/action.yml
+++ b/action.yml
@@ -240,6 +240,12 @@ runs:
               terminus multidev:create ${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV} ${PANTHEON_TARGET_ENV} --yes
             fi
 
+            # Ensure repo is not shallow; Pantheon rejects shallow pushes
+            if git rev-parse --is-shallow-repository >/dev/null 2>&1 && [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+              echo "Repository is shallow; unshallowing before push."
+              git fetch --unshallow origin || git fetch --depth=1000000 origin
+            fi
+
             # Push code to Pantheon
             git remote add pantheon ssh://codeserver.dev.${SITE_ID}@codeserver.dev.${SITE_ID}.drush.in:2222/~/repository.git
             git push pantheon HEAD:refs/heads/${PANTHEON_TARGET_ENV} --force

--- a/readme.md
+++ b/readme.md
@@ -166,6 +166,14 @@ If set to true, the action will skip installing Terminus. This is useful if you 
    type: boolean
 ```
 
+#### `skip_build_tools`
+If set to true, the action will skip the installation of the Terminus Build Tools plugin and will not use it to create Multidev environments or push code. This is useful if you _just_ want to push the code and are not interested in syncing the database and files as part of your deploy process.
+
+```yml
+   default: false
+   type: boolean
+```
+
 ## Additional recommendations
 
 ### Pin exact version of this action prior to the release of version 1.0.0


### PR DESCRIPTION
This PR is blocked by / builds from #113 

To solve #107 based on the work already done in #113, we can just make assumptions.
If a live environment does not exist, _rather than failing outright_ (even providing a more helpful error message) we can instead, just push in such a way that the workflow _won't_ fail, e.g. without Build Tools. Since that's the point of #113, we can simply add a check for a live environment. If a live environment does not exist, we continue the deploy as if `skip_build_tools` was set to `true` (and output a message to the log stating that the data might need to be synced manually).

In fact, we can skip installing build tools if there's no live environment, because there's no point. Build Tools will create the error when it deploys because there's no database on live to sync from, and we're bypassing that workflow anyway. So, the check for the live environment is done before the check for whether we're skipping build tools so we don't install build tools if we don't need it.

Fixes #107