### PR TITLE
Add check for multidev environment limit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -178,6 +178,38 @@ runs:
             git fetch --unshallow origin
           fi
 
+      - name: Check multidev limit
+        id: check_multidev_limit
+        shell: bash
+        run: |
+          # Check multidev limit
+          set +e
+          MAX_MULTIDEVS=$(terminus site:info ${{ inputs.site }} --field="Max Multidevs")
+          CURRENT_MULTIDEVS=$(terminus multidev:list ${{ inputs.site }} --format=list | grep -vE '^(dev|test|live)$' | wc -l)
+
+          if [ "$CURRENT_MULTIDEVS" -lt "$MAX_MULTIDEVS" ]; then
+            echo "multidev_available=true" >> $GITHUB_OUTPUT
+          else
+            echo "❌ Multidev limit reached."
+            echo "multidev_available=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Comment on PR if multidev limit reached
+        if: ${{ inputs.target_env == '' && steps.check_multidev_limit.outputs.multidev_available == 'false' }}
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          token: ${{ github.token }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ⚠️ Unable to create a Multidev environment for this pull request because the Pantheon Multidev limit for the site has been reached. Please contact Pantheon Support to request an increase in the multidev limit or delete unused Multidev environments.
+
+      - name: Abort deployment if multidev limit reached
+        if: ${{ inputs.target_env == '' && steps.check_multidev_limit.outputs.multidev_available == 'false' }}
+        shell: bash
+        run: |
+          echo "Aborting deployment due to multidev limit reached."
+          exit 1
+
       - name: Deployment Processing
         shell: bash
         id: deploy_to_pantheon

--- a/action.yml
+++ b/action.yml
@@ -199,12 +199,15 @@ runs:
 
       - name: Comment on PR if multidev limit reached
         if: ${{ inputs.target_env == '' && steps.check_multidev_limit.outputs.multidev_available == 'false' }}
-        uses: peter-evans/create-or-update-comment@v2
-        with:
-          token: ${{ github.token }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            ⚠️ Unable to create a Multidev environment for this pull request because the Pantheon Multidev limit for the site has been reached. Please contact Pantheon Support to request an increase in the multidev limit or delete unused Multidev environments.
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Comment on PR if multidev limit reached
+          set +e
+          gh pr comment "${PR_NUMBER}" --body "⚠️ Unable to create a Multidev environment for this pull request because the Pantheon Multidev limit for the site has been reached. Please contact Pantheon Support to request an increase in the multidev limit or delete unused Multidev environments."
+          
 
       - name: Abort deployment if multidev limit reached
         if: ${{ inputs.target_env == '' && steps.check_multidev_limit.outputs.multidev_available == 'false' }}

--- a/action.yml
+++ b/action.yml
@@ -181,11 +181,13 @@ runs:
       - name: Check multidev limit
         id: check_multidev_limit
         shell: bash
+        env:
+          PANTHEON_SITE: ${{ inputs.site }}
         run: |
           # Check multidev limit
           set +e
-          MAX_MULTIDEVS=$(terminus site:info ${{ inputs.site }} --field="Max Multidevs")
-          CURRENT_MULTIDEVS=$(terminus multidev:list ${{ inputs.site }} --format=list | grep -vE '^(dev|test|live)$' | wc -l)
+          MAX_MULTIDEVS=$(terminus site:info "${PANTHEON_SITE}" --field="Max Multidevs")
+          CURRENT_MULTIDEVS=$(terminus multidev:list "${PANTHEON_SITE}" --format=list | grep -vE '^(dev|test|live)$' | wc -l)
 
           if [ "$CURRENT_MULTIDEVS" -lt "$MAX_MULTIDEVS" ]; then
             echo "multidev_available=true" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -190,6 +190,7 @@ runs:
           CURRENT_MULTIDEVS=$(terminus multidev:list "${PANTHEON_SITE}" --format=list | grep -vE '^(dev|test|live)$' | wc -l)
 
           if [ "$CURRENT_MULTIDEVS" -lt "$MAX_MULTIDEVS" ]; then
+            echo "✅You have $((MAX_MULTIDEVS - CURRENT_MULTIDEVS)) multidev environments available."
             echo "multidev_available=true" >> $GITHUB_OUTPUT
           else
             echo "❌ Multidev limit reached."


### PR DESCRIPTION
Implement a check to prevent deployment when the Pantheon site reaches its multidev environment limit. If the limit is reached, the workflow posts a comment on the pull request and aborts the deployment, reducing resource consumption and providing immediate feedback to the user.

fixes #103