### PR TITLE
Add input for specifying build tools version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,12 @@ inputs:
     default: false
     type: boolean
 
+  build_tools_version:
+    description: "The version of the Terminus Build Tools plugin to install. By default, the action will install the latest stable version. You can specify a specific version or branch if needed."
+    required: false
+    type: string
+    default: ""
+
   # todo checkout_repo:
   #   description: "A boolean for whether or not this composite step should checkout the git repo. Set to false if a checkout has already been perf"
 

--- a/action.yml
+++ b/action.yml
@@ -153,7 +153,15 @@ runs:
 
       - name: Install Terminus Plugin
         shell: bash
-        run: terminus self:plugin:install "pantheon-systems/terminus-build-tools-plugin:3.x-dev"
+        run: |
+          BUILD_TOOLS_VERSION="${{ inputs.build_tools_version }}"
+          if [ -z "$BUILD_TOOLS_VERSION" ]; then
+            echo "Installing latest stable version of Terminus Build Tools plugin"
+            terminus self:plugin:install pantheon-systems/terminus-build-tools-plugin
+          else
+            echo "Installing specified version (${BUILD_TOOLS_VERSION}) of Terminus Build Tools plugin"
+            terminus self:plugin:install "pantheon-systems/terminus-build-tools-plugin:${BUILD_TOOLS_VERSION}"
+          fi
 
       - name: Configure Git User
         shell: bash

--- a/action.yml
+++ b/action.yml
@@ -153,8 +153,10 @@ runs:
 
       - name: Install Terminus Plugin
         shell: bash
+        env:
+          BUILD_TOOLS_VERSION_INPUT: ${{ inputs.build_tools_version }}
         run: |
-          BUILD_TOOLS_VERSION="${{ inputs.build_tools_version }}"
+          BUILD_TOOLS_VERSION="${BUILD_TOOLS_VERSION_INPUT}"
           if [ -z "$BUILD_TOOLS_VERSION" ]; then
             echo "Installing latest stable version of Terminus Build Tools plugin"
             terminus self:plugin:install pantheon-systems/terminus-build-tools-plugin

--- a/readme.md
+++ b/readme.md
@@ -166,6 +166,14 @@ If set to true, the action will skip installing Terminus. This is useful if you 
    type: boolean
 ```
 
+#### `build_tools_version`
+The version of Pantheon Build Tools to install. By default, the latest stable version will be installed. This parameter is useful when using this action in a workflow that requires a specific version of Build Tools.
+
+```yml
+   default: ""
+   type: string
+```
+
 ## Additional recommendations
 
 ### Pin exact version of this action prior to the release of version 1.0.0

--- a/readme.md
+++ b/readme.md
@@ -167,7 +167,7 @@ If set to true, the action will skip installing Terminus. This is useful if you 
 ```
 
 #### `build_tools_version`
-The version of Pantheon Build Tools to install. By default, the latest stable version will be installed. This parameter is useful when using this action in a workflow that requires a specific version of Build Tools.
+The version of Pantheon's Terminus Build Tools Plugin to install. By default, the latest stable version will be installed. This parameter is used by Pantheon engineers to test changes between the Terminus plugin and this GitHub Action. Customer can also use it if they immediately need an alternate version of Build Tools. Open an issue if you find yourself regularly needing this parameter.
 
 ```yml
    default: ""

--- a/readme.md
+++ b/readme.md
@@ -174,6 +174,18 @@ The version of Pantheon's Terminus Build Tools Plugin to install. By default, th
    type: string
 ```
 
+**Example usage:**
+```yml
+    - name: Push to Pantheon
+      uses: pantheon-systems/push-to-pantheon@57-use-tagged-build-tools
+      with:
+        ssh_key: ${{ secrets.PANTHEON_SSH_KEY }}
+        machine_token: ${{ secrets.TERMINUS_MACHINE_TOKEN }}
+        site: ${{ vars.PANTHEON_SITE }}
+        clone_content: true
+        build_tools_version: "dev-cms-637-gitlab-infer"
+```
+
 ## Additional recommendations
 
 ### Pin exact version of this action prior to the release of version 1.0.0

--- a/readme.md
+++ b/readme.md
@@ -167,7 +167,7 @@ If set to true, the action will skip installing Terminus. This is useful if you 
 ```
 
 #### `build_tools_version`
-The version of Pantheon's Terminus Build Tools Plugin to install. By default, the latest stable version will be installed. This parameter is used by Pantheon engineers to test changes between the Terminus plugin and this GitHub Action. Customer can also use it if they immediately need an alternate version of Build Tools. Open an issue if you find yourself regularly needing this parameter.
+The version of Pantheon's Terminus Build Tools Plugin to install. By default, the latest stable version will be installed. This parameter is primarily used to test changes between the Terminus plugin and this GitHub Action. Customers can also use it if they immediately need an alternate version of Build Tools. Open an issue if you find yourself regularly needing this parameter.
 
 ```yml
    default: ""


### PR DESCRIPTION
Introduce an input to allow workflows to specify the version of the Terminus Build Tools plugin, enhancing flexibility and removing hard-coded values. Update the installation logic to use the specified version or default to the latest stable version. Include documentation for the new input.

fixes #57