### PR TITLE
Re-add check for live env for Build Tools install

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -48,6 +48,6 @@ jobs:
         relative_site_root: "pr-code/.github/testing_fixtures/dtp-nearly-empty-site"
         git_user_name: "Test Name"
         git_user_email: "test@example.com"
-        git_commit_message: "This is an automated commit message from GitHub Actions."
+        git_commit_message: "This is an automated commit message from GitHub Actions for PR #${{ github.event.pull_request.number }}."
         delete_old_environments: true
         clone_content: true

--- a/action.yml
+++ b/action.yml
@@ -264,7 +264,7 @@ runs:
 
       - name: Install Terminus Plugin
         shell: bash
-        if: ${{ inputs.skip_build_tools != 'true' }}
+        if: ${{ inputs.skip_build_tools != 'true' && steps.check_live_env.outputs.live_env_exists == 'true' }}
         env:
           BUILD_TOOLS_VERSION_INPUT: ${{ inputs.build_tools_version }}
         run: |


### PR DESCRIPTION
We shouldn't install build tools if we can't use it. This fixes an issue (well, sort of an issue) where build tools was being installed when it didn't need to be (because there's no live environment). This was previously added in 82cfcc6 but lost, likely due to a bad merge / merge conflict.