### PR TITLE
Implement comprehensive test suite for parameter coverage

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -11,43 +11,33 @@ on:
       - '.github/testing_fixtures/**'
       - 'action.yml'
   workflow_dispatch:
+    inputs:
+      suite:
+        description: 'Which test suite(s) to run'
+        type: choice
+        options:
+          - all
+          - standard
+          - content
+          - git
+          - terminus
+          - advanced
+        default: all
 
 jobs:
-  deploy_pr:
-    name: Deploy Pull Request
-    # This job uses `pull_request_target` to gain access to secrets, which
+  run_test_suites:
+    name: Run Test Suites
+    # This workflow uses `pull_request_target` to gain access to secrets, which
     # are not available on normal `pull_request` events for forks.
-    # The two-step checkout process below is critical for security.
-    # It ensures that we are executing trusted code from the base repository
-    # while operating on the untrusted code from the pull request.
+    # The two-step checkout process is handled within the reusable test-suites workflow.
     permissions:
       deployments: write
-      contents: write # needed to checkout the PR code.
+      contents: write
       pull-requests: read
-    runs-on: ubuntu-latest
-    steps:
-    # Checkout the base repository at the current commit.
-    # This is the trusted code that will be executed.
-    - uses: actions/checkout@v6
-
-    # Checkout the pull request code into a subdirectory.
-    # This is the code that will be deployed.
-    - name: Checkout PR code
-      uses: actions/checkout@v6
-      with:
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
-        ref: ${{ github.event.pull_request.head.ref }}
-        path: pr-code
-    - name: deploy to Pantheon
-      uses: ./
-      with:
-        ssh_key: ${{ secrets.PANTHEON_SSH_KEY }}
-        machine_token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
-        site: dtp-nearly-empty-site
-        target_env: "pr-${{ github.event.pull_request.number }}"
-        relative_site_root: "pr-code/.github/testing_fixtures/dtp-nearly-empty-site"
-        git_user_name: "Test Name"
-        git_user_email: "test@example.com"
-        git_commit_message: "This is an automated commit message from GitHub Actions for PR #${{ github.event.pull_request.number }}."
-        delete_old_environments: true
-        clone_content: true
+    uses: ./.github/workflows/test-suites.yml
+    with:
+      env_prefix: ${{ github.event.pull_request.number || 'manual' }}
+      suite: ${{ github.event_name == 'workflow_dispatch' && inputs.suite || 'all' }}
+    secrets:
+      PANTHEON_SSH_KEY: ${{ secrets.PANTHEON_SSH_KEY }}
+      PANTHEON_MACHINE_TOKEN: ${{ secrets.PANTHEON_MACHINE_TOKEN }}

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -7,92 +7,52 @@ concurrency:
 on:
   workflow_dispatch:
     inputs:
-      install_terminus:
-        description: 'Install Terminus during deploy?'
-        required: true
-        default: 'Yes'
+      suite:
+        description: 'Which test suite(s) to run'
         type: choice
         options:
-          - 'Yes'
-          - 'No'
-      run_cleanup:
-        description: 'Run cleanup after successful deploy?'
-        required: true
-        default: 'No'
-        type: choice
-        options:
-          - 'Yes'
-          - 'No'
+          - all
+          - standard
+          - content
+          - git
+          - terminus
+          - advanced
+        default: all
 
 jobs:
-  test_workflow_no_terminus_install:
-    name: Test Deploy without Terminus Install
-    if: ${{ github.event.inputs.install_terminus == 'No' }}
+  compute_env_prefix:
+    name: Compute Environment Prefix
+    runs-on: ubuntu-latest
+    outputs:
+      env_prefix: ${{ steps.compute.outputs.env_prefix }}
+    steps:
+      - name: Compute environment prefix
+        id: compute
+        run: |
+          # For 0.x branch, use "0x" as prefix
+          # For other branches, use first 6 chars of sanitized branch name
+          if [ "${{ github.ref_name }}" == "0.x" ]; then
+            ENV_PREFIX="0x"
+          else
+            # Remove non-alphanumeric characters (except hyphens) and take first 6 chars
+            SHORT_REF=$(echo "${{ github.ref_name }}" | sed 's/[^a-zA-Z0-9-]//g' | cut -c1-6)
+            ENV_PREFIX="${SHORT_REF}"
+          fi
+
+          echo "Computed environment prefix: ${ENV_PREFIX}"
+          echo "env_prefix=${ENV_PREFIX}" >> $GITHUB_OUTPUT
+
+  run_test_suites:
+    name: Run Test Suites
+    needs: compute_env_prefix
     permissions:
       deployments: write
       contents: write
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v6
-
-    - name: Install Terminus
-      uses: pantheon-systems/terminus-github-actions@v1.2.7
-      with:
-        pantheon-machine-token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
-
-    - name: Run Terminus Command
-      run: |
-        terminus --version
-        terminus art
-        terminus auth:whoami
-        terminus site:info dtp-nearly-empty-site
-      shell: bash
-
-    - name: Set short branch name
-      id: vars
-      run: echo "short_ref_name=$(echo ${{ github.ref_name }} | sed 's/[^a-zA-Z0-9-]//g' | cut -c1-8)" >> $GITHUB_OUTPUT
-
-    - name: deploy to Pantheon
-      uses: ./
-      with:
-        ssh_key: ${{ secrets.PANTHEON_SSH_KEY }}
-        machine_token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
-        site: dtp-nearly-empty-site
-        target_env: ${{ github.ref_name == '0.x' && 'dev' || format('wd-{0}', steps.vars.outputs.short_ref_name) }}
-        relative_site_root: ".github/testing_fixtures/dtp-nearly-empty-site"
-        git_user_name: "Test Name"
-        git_user_email: "test@example.com"
-        git_commit_message: "This is a manual test deployment from GitHub Actions."
-        clone_content: true
-        delete_old_environments: ${{ github.event.inputs.run_cleanup == 'Yes' }}
-
-  test_workflow_with_terminus_install:
-    name: Test Deploy with Terminus Install
-    if: ${{ github.event.inputs.install_terminus == 'Yes' }}
-    permissions:
-        deployments: write
-        contents: write
-    runs-on: ubuntu-latest
-    steps:
-        - name: Checkout Repository
-          uses: actions/checkout@v6
-
-        - name: Set short branch name
-          id: vars
-          run: echo "short_ref_name=$(echo ${{ github.ref_name }} | sed 's/[^a-zA-Z0-9-]//g' | cut -c1-8)" >> $GITHUB_OUTPUT
-
-        - name: deploy to Pantheon
-          uses: ./
-          with:
-            ssh_key: ${{ secrets.PANTHEON_SSH_KEY }}
-            machine_token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
-            site: dtp-nearly-empty-site
-            target_env: ${{ github.ref_name == '0.x' && 'dev' || format('wd-{0}', steps.vars.outputs.short_ref_name) }}
-            relative_site_root: ".github/testing_fixtures/dtp-nearly-empty-site"
-            git_user_name: "Test Name"
-            git_user_email: "test@example.com"
-            git_commit_message: "This is a manual test deployment from GitHub Actions."
-            clone_content: true
-            delete_old_environments: ${{ github.event.inputs.run_cleanup == 'Yes' }}
-       
+      pull-requests: read
+    uses: ./.github/workflows/test-suites.yml
+    with:
+      env_prefix: ${{ needs.compute_env_prefix.outputs.env_prefix }}
+      suite: ${{ inputs.suite }}
+    secrets:
+      PANTHEON_SSH_KEY: ${{ secrets.PANTHEON_SSH_KEY }}
+      PANTHEON_MACHINE_TOKEN: ${{ secrets.PANTHEON_MACHINE_TOKEN }}

--- a/.github/workflows/test-suites.yml
+++ b/.github/workflows/test-suites.yml
@@ -90,7 +90,7 @@ jobs:
           fi
 
   content:
-    name: Content Management
+    name: Clone Content
     if: inputs.suite == 'all' || inputs.suite == 'content'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-suites.yml
+++ b/.github/workflows/test-suites.yml
@@ -220,7 +220,7 @@ jobs:
           target_env: ${{ inputs.env_prefix }}-term
           relative_site_root: ${{ github.event_name == 'pull_request_target' && 'pr-code/.github/testing_fixtures/dtp-nearly-empty-site' || '.github/testing_fixtures/dtp-nearly-empty-site' }}
           skip_terminus_install: true
-          build_tools_version: dev-main
+          build_tools_version: dev-3.x
 
       - name: Verify deployment success
         run: |

--- a/.github/workflows/test-suites.yml
+++ b/.github/workflows/test-suites.yml
@@ -220,7 +220,7 @@ jobs:
           target_env: ${{ inputs.env_prefix }}-term
           relative_site_root: ${{ github.event_name == 'pull_request_target' && 'pr-code/.github/testing_fixtures/dtp-nearly-empty-site' || '.github/testing_fixtures/dtp-nearly-empty-site' }}
           skip_terminus_install: true
-          build_tools_version: dev-3.x
+          build_tools_version: 3.x-dev
 
       - name: Verify deployment success
         run: |

--- a/.github/workflows/test-suites.yml
+++ b/.github/workflows/test-suites.yml
@@ -1,0 +1,303 @@
+name: Test Suites
+
+on:
+  workflow_call:
+    inputs:
+      suite:
+        description: 'Which suite(s) to run'
+        type: string
+        default: 'all'
+        required: false
+      env_prefix:
+        description: 'Environment name prefix (e.g., "123", "126mor", "0x")'
+        type: string
+        required: true
+    secrets:
+      PANTHEON_SSH_KEY:
+        required: true
+      PANTHEON_MACHINE_TOKEN:
+        required: true
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: 'Which suite(s) to run'
+        type: choice
+        options:
+          - all
+          - standard
+          - content
+          - git
+          - terminus
+          - advanced
+        default: all
+      env_prefix:
+        description: 'Environment name prefix (e.g., "test", "demo")'
+        type: string
+        required: true
+
+permissions:
+  deployments: write
+  contents: write
+  pull-requests: read
+
+jobs:
+  standard:
+    name: Standard Deployment
+    if: inputs.suite == 'all' || inputs.suite == 'standard'
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout base repository code (trusted)
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      # Checkout PR code to subdirectory (untrusted) - only for pull_request_target
+      - name: Checkout PR code
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          path: pr-code
+
+      - name: Deploy to Pantheon
+        uses: ./
+        with:
+          ssh_key: ${{ secrets.PANTHEON_SSH_KEY }}
+          machine_token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
+          site: dtp-nearly-empty-site
+          target_env: ${{ inputs.env_prefix }}-std
+          relative_site_root: ${{ github.event_name == 'pull_request_target' && 'pr-code/.github/testing_fixtures/dtp-nearly-empty-site' || '.github/testing_fixtures/dtp-nearly-empty-site' }}
+
+      - name: Verify deployment success
+        run: |
+          echo "Deployment completed successfully"
+          echo "Environment: ${{ inputs.env_prefix }}-std"
+
+      - name: Check environment URL accessibility
+        run: |
+          ENV_URL="https://${{ inputs.env_prefix }}-std-dtp-nearly-empty-site.pantheonsite.io"
+          echo "Checking accessibility of ${ENV_URL}"
+
+          # Wait a few seconds for environment to be fully ready
+          sleep 10
+
+          # Try to fetch the URL (fail if not accessible)
+          if curl -sSf "${ENV_URL}" > /dev/null; then
+            echo "::notice::✅ Environment URL is accessible"
+          else
+            echo "::error::❌ Environment URL is not accessible"
+            exit 1
+          fi
+
+  content:
+    name: Content Management
+    if: inputs.suite == 'all' || inputs.suite == 'content'
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout base repository code (trusted)
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      # Checkout PR code to subdirectory (untrusted) - only for pull_request_target
+      - name: Checkout PR code
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          path: pr-code
+
+      - name: Deploy to Pantheon
+        uses: ./
+        with:
+          ssh_key: ${{ secrets.PANTHEON_SSH_KEY }}
+          machine_token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
+          site: dtp-nearly-empty-site
+          target_env: ${{ inputs.env_prefix }}-cont
+          relative_site_root: ${{ github.event_name == 'pull_request_target' && 'pr-code/.github/testing_fixtures/dtp-nearly-empty-site' || '.github/testing_fixtures/dtp-nearly-empty-site' }}
+          clone_content: true
+          source_env: dev
+
+      - name: Verify deployment success
+        run: |
+          echo "Deployment completed successfully"
+          echo "Environment: ${{ inputs.env_prefix }}-cont"
+
+      - name: Check environment URL accessibility
+        run: |
+          ENV_URL="https://${{ inputs.env_prefix }}-cont-dtp-nearly-empty-site.pantheonsite.io"
+          echo "Checking accessibility of ${ENV_URL}"
+          sleep 10
+          if curl -sSf "${ENV_URL}" > /dev/null; then
+            echo "::notice::✅ Environment URL is accessible"
+          else
+            echo "::error::❌ Environment URL is not accessible"
+            exit 1
+          fi
+
+  git-only:
+    name: Git-Only Deployment
+    if: inputs.suite == 'all' || inputs.suite == 'git'
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout base repository code (trusted)
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      # Checkout PR code to subdirectory (untrusted) - only for pull_request_target
+      - name: Checkout PR code
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          path: pr-code
+
+      - name: Deploy to Pantheon
+        uses: ./
+        with:
+          ssh_key: ${{ secrets.PANTHEON_SSH_KEY }}
+          machine_token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
+          site: dtp-nearly-empty-site
+          target_env: ${{ inputs.env_prefix }}-git
+          relative_site_root: ${{ github.event_name == 'pull_request_target' && 'pr-code/.github/testing_fixtures/dtp-nearly-empty-site' || '.github/testing_fixtures/dtp-nearly-empty-site' }}
+          skip_build_tools: true
+          git_user_name: "Git Deploy Test"
+          git_user_email: "git-deploy@example.com"
+          git_commit_message: "Git-only deployment test"
+
+      - name: Verify deployment success
+        run: |
+          echo "Deployment completed successfully"
+          echo "Environment: ${{ inputs.env_prefix }}-git"
+
+      - name: Check environment URL accessibility
+        run: |
+          ENV_URL="https://${{ inputs.env_prefix }}-git-dtp-nearly-empty-site.pantheonsite.io"
+          echo "Checking accessibility of ${ENV_URL}"
+          sleep 10
+          if curl -sSf "${ENV_URL}" > /dev/null; then
+            echo "::notice::✅ Environment URL is accessible"
+          else
+            echo "::error::❌ Environment URL is not accessible"
+            exit 1
+          fi
+
+  terminus-preinstalled:
+    name: Terminus Pre-installed
+    if: inputs.suite == 'all' || inputs.suite == 'terminus'
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout base repository code (trusted)
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      # Checkout PR code to subdirectory (untrusted) - only for pull_request_target
+      - name: Checkout PR code
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          path: pr-code
+
+      - name: Query Build Tools versions
+        id: build_tools_version
+        run: |
+          # Fetch the latest releases of the Build Tools plugin
+          VERSIONS=$(gh api repos/pantheon-systems/terminus-build-tools-plugin/releases --jq '.[].tag_name' | grep -v 'alpha\|beta\|rc' | head -n 3)
+
+          # Get the 2nd most recent stable version
+          SECOND_MOST_RECENT=$(echo "$VERSIONS" | sed -n '2p')
+
+          echo "Available stable versions (latest 3):"
+          echo "$VERSIONS"
+          echo "Selected version (2nd most recent): $SECOND_MOST_RECENT"
+
+          echo "BUILD_TOOLS_VERSION=$SECOND_MOST_RECENT" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Pre-install Terminus
+        uses: pantheon-systems/terminus-github-actions@v1
+        with:
+          pantheon-machine-token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
+
+      - name: Verify Terminus installation
+        run: |
+          terminus --version
+          echo "::notice::Terminus is pre-installed"
+
+      - name: Deploy to Pantheon
+        uses: ./
+        with:
+          ssh_key: ${{ secrets.PANTHEON_SSH_KEY }}
+          machine_token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
+          site: dtp-nearly-empty-site
+          target_env: ${{ inputs.env_prefix }}-term
+          relative_site_root: ${{ github.event_name == 'pull_request_target' && 'pr-code/.github/testing_fixtures/dtp-nearly-empty-site' || '.github/testing_fixtures/dtp-nearly-empty-site' }}
+          skip_terminus_install: true
+          build_tools_version: ${{ steps.build_tools_version.outputs.BUILD_TOOLS_VERSION }}
+
+      - name: Verify deployment success
+        run: |
+          echo "Deployment completed successfully"
+          echo "Environment: ${{ inputs.env_prefix }}-term"
+
+      - name: Check environment URL accessibility
+        run: |
+          ENV_URL="https://${{ inputs.env_prefix }}-term-dtp-nearly-empty-site.pantheonsite.io"
+          echo "Checking accessibility of ${ENV_URL}"
+          sleep 10
+          if curl -sSf "${ENV_URL}" > /dev/null; then
+            echo "::notice::✅ Environment URL is accessible"
+          else
+            echo "::error::❌ Environment URL is not accessible"
+            exit 1
+          fi
+
+  advanced:
+    name: Advanced Deployment
+    if: inputs.suite == 'all' || inputs.suite == 'advanced'
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout base repository code (trusted)
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      # Checkout PR code to subdirectory (untrusted) - only for pull_request_target
+      - name: Checkout PR code
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          path: pr-code
+
+      - name: Deploy to Pantheon
+        uses: ./
+        with:
+          ssh_key: ${{ secrets.PANTHEON_SSH_KEY }}
+          machine_token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
+          site: dtp-nearly-empty-site
+          target_env: ${{ inputs.env_prefix }}-adv
+          relative_site_root: ${{ github.event_name == 'pull_request_target' && 'pr-code/.github/testing_fixtures/dtp-nearly-empty-site' || '.github/testing_fixtures/dtp-nearly-empty-site' }}
+          delete_old_environments: true
+          clone_content: true
+
+      - name: Verify deployment success
+        run: |
+          echo "Deployment completed successfully"
+          echo "Environment: ${{ inputs.env_prefix }}-adv"
+
+      - name: Check environment URL accessibility
+        run: |
+          ENV_URL="https://${{ inputs.env_prefix }}-adv-dtp-nearly-empty-site.pantheonsite.io"
+          echo "Checking accessibility of ${ENV_URL}"
+          sleep 10
+          if curl -sSf "${ENV_URL}" > /dev/null; then
+            echo "::notice::✅ Environment URL is accessible"
+          else
+            echo "::error::❌ Environment URL is not accessible"
+            exit 1
+          fi

--- a/.github/workflows/test-suites.yml
+++ b/.github/workflows/test-suites.yml
@@ -201,23 +201,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           path: pr-code
 
-      - name: Query Build Tools versions
-        id: build_tools_version
-        run: |
-          # Fetch the latest releases of the Build Tools plugin
-          VERSIONS=$(gh api repos/pantheon-systems/terminus-build-tools-plugin/releases --jq '.[].tag_name' | grep -v 'alpha\|beta\|rc' | head -n 3)
-
-          # Get the 2nd most recent stable version
-          SECOND_MOST_RECENT=$(echo "$VERSIONS" | sed -n '2p')
-
-          echo "Available stable versions (latest 3):"
-          echo "$VERSIONS"
-          echo "Selected version (2nd most recent): $SECOND_MOST_RECENT"
-
-          echo "BUILD_TOOLS_VERSION=$SECOND_MOST_RECENT" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ github.token }}
-
       - name: Pre-install Terminus
         uses: pantheon-systems/terminus-github-actions@v1
         with:
@@ -237,7 +220,7 @@ jobs:
           target_env: ${{ inputs.env_prefix }}-term
           relative_site_root: ${{ github.event_name == 'pull_request_target' && 'pr-code/.github/testing_fixtures/dtp-nearly-empty-site' || '.github/testing_fixtures/dtp-nearly-empty-site' }}
           skip_terminus_install: true
-          build_tools_version: ${{ steps.build_tools_version.outputs.BUILD_TOOLS_VERSION }}
+          build_tools_version: dev-main
 
       - name: Verify deployment success
         run: |

--- a/action.yml
+++ b/action.yml
@@ -218,6 +218,15 @@ runs:
             terminus self:plugin:install "pantheon-systems/terminus-build-tools-plugin:${BUILD_TOOLS_VERSION}"
           fi
 
+      - name: Verify Build Tools Plugin Installation
+        shell: bash
+        if: ${{ inputs.skip_build_tools != 'true' && steps.check_live_env.outputs.live_env_exists == 'true' }}
+        env:
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          # Verify Build Tools plugin installation
+          ${WORKSPACE}/scripts/main.sh verify_build_tools
+
       - name: Configure Git User
         shell: bash
         env:
@@ -253,6 +262,10 @@ runs:
           SKIP_BUILD_TOOLS: ${{ inputs.skip_build_tools }}
           LIVE_ENV_EXISTS: ${{ steps.check_live_env.outputs.live_env_exists }}
           WORKSPACE: ${{ github.workspace }}
+          CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          CI_BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          CI_PROJECT_USERNAME: ${{ github.repository_owner }}
+          CI_PROJECT_REPONAME: ${{ github.event.repository.name }}
         run: |
           # Push to Pantheon
           ${WORKSPACE}/scripts/main.sh push_to_pantheon

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -269,7 +269,11 @@ function push_to_pantheon() {
 	fi
 
 	# For all other pushes, use Build Tools.
-	terminus -n build:env:create "${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV}" "${PANTHEON_TARGET_ENV}" --yes --message="${PANTHEON_COMMIT_MESSAGE}" "${PANTHEON_CLONE_CONTENT_FLAG}"
+	if [ -n "${PANTHEON_CLONE_CONTENT_FLAG}" ]; then
+		terminus -n build:env:create "${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV}" "${PANTHEON_TARGET_ENV}" --yes --message="${PANTHEON_COMMIT_MESSAGE}" "${PANTHEON_CLONE_CONTENT_FLAG}"
+	else
+		terminus -n build:env:create "${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV}" "${PANTHEON_TARGET_ENV}" --yes --message="${PANTHEON_COMMIT_MESSAGE}"
+	fi
 }
 
 # Function to delete a GitHub environment and all of its associated deployments.

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -20,6 +20,7 @@ function main() {
 	- get_missing_permissions_help: Print a help message with instructions for how to add the missing permissions to your workflow.
 	- setup_ssh_hostkeys: Set up SSH host keys for Pantheon.
 	- prepare_site_root: Prepare the site root by cloning the Pantheon repository, copying files from the specified SITE_ROOT, and setting up the GitHub origin for Build Tools compatibility.
+	- verify_build_tools: Verify that the Terminus Build Tools plugin is installed and available.
 	- push_to_pantheon: Push code to Pantheon, either via Git or Build Tools depending on configuration and environment state.
 	- cleanup: Clean up stale Pantheon multidev environments. This includes environments associated with closed PRs as well as old environments matching a specified pattern.
 	"
@@ -36,7 +37,7 @@ function main() {
 	fi
 
 	# Check for a valid command.
-	if [ "$1" != 'get_target_env' ] && [ "$1" != 'check_missing_permissions' ] && [ "$1" != 'get_missing_permissions_help' ] && [ "$1" != 'setup_ssh_hostkeys' ] && [ "$1" != 'prepare_site_root' ] && [ "$1" != 'push_to_pantheon' ] && [ "$1" != 'cleanup' ]; then
+	if [ "$1" != 'get_target_env' ] && [ "$1" != 'check_missing_permissions' ] && [ "$1" != 'get_missing_permissions_help' ] && [ "$1" != 'setup_ssh_hostkeys' ] && [ "$1" != 'prepare_site_root' ] && [ "$1" != 'push_to_pantheon' ] && [ "$1" != 'cleanup' ] && [ "$1" != 'verify_build_tools' ]; then
 		echo -e "${red}Invalid command: $1${normal}"
 		echo -e "${help_msg}"
 		exit 1
@@ -143,9 +144,29 @@ function setup_ssh_hostkeys() {
 	echo -e "${green}✅ SSH host keys configured.${normal}"
 }
 
-# Prepare the site root by cloning the Pantheon repository, copying files from 
-# the specified SITE_ROOT, and setting up the GitHub origin for Build Tools 
-# compatibility.
+# Verify that the Terminus Build Tools plugin is installed and available.
+function verify_build_tools() {
+	echo -e "${yellow}Verifying Build Tools plugin installation...${normal}"
+
+	# Check if Build Tools plugin is installed
+	if terminus self:plugin:list | grep -q 'pantheon-systems/terminus-build-tools-plugin'; then
+		# Try to get version info
+		PLUGIN_INFO=$(terminus self:plugin:list --format=json 2>/dev/null | grep -A 5 'terminus-build-tools-plugin' | grep 'version' | head -1 || echo "")
+		if [ -n "$PLUGIN_INFO" ]; then
+			echo -e "${green}✅ Build Tools plugin is installed: ${PLUGIN_INFO}${normal}"
+		else
+			echo -e "${green}✅ Build Tools plugin is installed${normal}"
+		fi
+	else
+		echo -e "${red}❌ Build Tools plugin installation failed. Plugin not found in plugin list.${normal}"
+		echo -e "${red}This is required for deployment. Failing workflow.${normal}"
+		exit 1
+	fi
+}
+
+# Prepare the site root by cloning the Pantheon repository, copying 
+# files from the specified SITE_ROOT, and setting up the GitHub origin 
+# for Build Tools compatibility.
 function prepare_site_root() {
 	if [ -n "$SITE_ROOT" ]; then
 		echo -e "${yellow}Preparing site from relative path:${normal}${bold} ${SITE_ROOT}${normal}"

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -149,14 +149,10 @@ function verify_build_tools() {
 	echo -e "${yellow}Verifying Build Tools plugin installation...${normal}"
 
 	# Check if Build Tools plugin is installed
-	if terminus self:plugin:list | grep -q 'pantheon-systems/terminus-build-tools-plugin'; then
-		# Try to get version info
-		PLUGIN_INFO=$(terminus self:plugin:list --format=json 2>/dev/null | grep -A 5 'terminus-build-tools-plugin' | grep 'version' | head -1 || echo "")
-		if [ -n "$PLUGIN_INFO" ]; then
-			echo -e "${green}✅ Build Tools plugin is installed: ${PLUGIN_INFO}${normal}"
-		else
-			echo -e "${green}✅ Build Tools plugin is installed${normal}"
-		fi
+	if terminus self:plugin:list --format=list --field=name | grep -q '^terminus-build-tools-plugin$'; then
+		# Get version info
+		VERSION=$(terminus self:plugin:list --format=json | grep -A 3 '"name": "terminus-build-tools-plugin"' | grep '"installed_version"' | sed 's/.*": "\(.*\)".*/\1/')
+		echo -e "${green}✅ Build Tools plugin is installed (version: ${VERSION})${normal}"
 	else
 		echo -e "${red}❌ Build Tools plugin installation failed. Plugin not found in plugin list.${normal}"
 		echo -e "${red}This is required for deployment. Failing workflow.${normal}"

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -316,23 +316,43 @@ function cleanup() {
 	# associated with closed or merged pull requests.
 	terminus build:env:delete:pr "$PANTHEON_SITE" --yes
 
-	# The block below is intended to delete old environments that are not 
-	# associated with pull requests. This is useful for cleaning up 
+	# The block below is intended to delete old environments that are not
+	# associated with pull requests. This is useful for cleaning up
 	# environments created by manual workflows or other automated processes.
-	if [ -z "$MULTIDEV_DELETE_PATTERN" ] || [ -z "$DELETE_OLD_MULTIDEVS" ] || [ "$DELETE_OLD_MULTIDEVS" != "true" ]; then
-		echo -e "${red}No MULTIDEV_DELETE_PATTERN set or delete_old_environments was not set to true. Skipping deletion of old environments...${normal}"
+	if [ -z "$DELETE_OLD_MULTIDEVS" ] || [ "$DELETE_OLD_MULTIDEVS" != "true" ]; then
+		echo -e "${red}delete_old_environments was not set to true. Skipping deletion of old environments...${normal}"
 		exit 0
 	fi
 
 	# List all environments, filter out the standard dev/test/live, find the ones
-	# that match our deletion pattern, and then exclude the most recent one.
+	# that match our deletion patterns (both legacy and new), and exclude the current target env.
+	# Built-in test suite patterns: *-std, *-cont, *-git, *-term, *-adv
+	# Legacy manual deploy pattern: wd-*
+	# User-specified pattern: $MULTIDEV_DELETE_PATTERN (optional)
 	ALL_ENVS=$(terminus env:list "$PANTHEON_SITE" --format=list)
-	OLDEST_ENVIRONMENTS=$(echo "$ALL_ENVS" \
-		| grep -v dev \
-		| grep -v test \
-		| grep -v live \
-		| grep "$MULTIDEV_DELETE_PATTERN" \
-		| grep -v '^pr-' \
+
+	# Start with environments matching suite patterns or legacy wd- pattern
+	FILTERED_ENVS=$(echo "$ALL_ENVS" \
+		| grep -v '^dev$' \
+		| grep -v '^test$' \
+		| grep -v '^live$' \
+		| grep -E '(^wd-|-std$|-cont$|-git$|-term$|-adv$)')
+
+	# If MULTIDEV_DELETE_PATTERN is set, also include environments matching that pattern
+	# (excluding pr- environments which are handled by build:env:delete:pr)
+	if [ -n "$MULTIDEV_DELETE_PATTERN" ]; then
+		PATTERN_ENVS=$(echo "$ALL_ENVS" \
+			| grep -v '^dev$' \
+			| grep -v '^test$' \
+			| grep -v '^live$' \
+			| grep "$MULTIDEV_DELETE_PATTERN" \
+			| grep -v '^pr-')
+		FILTERED_ENVS=$(echo -e "${FILTERED_ENVS}\n${PATTERN_ENVS}" | sort -u)
+	fi
+
+	# Exclude the current target environment and keep all but the most recent
+	OLDEST_ENVIRONMENTS=$(echo "$FILTERED_ENVS" \
+		| grep -v "^${PANTHEON_TARGET_ENV}$" \
 		| sort \
 		| sed -e '$d')
 

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -328,12 +328,27 @@ function cleanup() {
 		exit 0
 	fi
 
+	# Age threshold in days - only delete environments older than this
+	# Default to 14 days if not specified
+	AGE_THRESHOLD_DAYS="${MULTIDEV_AGE_THRESHOLD_DAYS:-14}"
+	CURRENT_TIMESTAMP=$(date +%s)
+	AGE_THRESHOLD_SECONDS=$((AGE_THRESHOLD_DAYS * 86400))
+	echo -e "${yellow}Age threshold: ${normal}${bold}${AGE_THRESHOLD_DAYS} days${normal}"
+
 	# List all environments, filter out the standard dev/test/live, find the ones
 	# that match our deletion patterns (both legacy and new), and exclude the current target env.
 	# Built-in test suite patterns: *-std, *-cont, *-git, *-term, *-adv
 	# Legacy manual deploy pattern: wd-*
 	# User-specified pattern: $MULTIDEV_DELETE_PATTERN (optional)
 	ALL_ENVS=$(terminus env:list "$PANTHEON_SITE" --format=list)
+
+	# Extract the prefix from PANTHEON_TARGET_ENV to protect all concurrent suite environments
+	# e.g., "126-mo-std" -> "126-mo", "pr-123-git" -> "pr-123", "0x-term" -> "0x"
+	ENV_PREFIX=""
+	if [[ "$PANTHEON_TARGET_ENV" =~ ^(.+)-(std|cont|git|term|adv)$ ]]; then
+		ENV_PREFIX="${BASH_REMATCH[1]}"
+		echo -e "${yellow}Protecting all environments with prefix: ${normal}${bold}${ENV_PREFIX}-*${normal}"
+	fi
 
 	# Start with environments matching suite patterns or legacy wd- pattern
 	FILTERED_ENVS=$(echo "$ALL_ENVS" \
@@ -354,11 +369,35 @@ function cleanup() {
 		FILTERED_ENVS=$(echo -e "${FILTERED_ENVS}\n${PATTERN_ENVS}" | sort -u)
 	fi
 
-	# Exclude the current target environment and keep all but the most recent
-	OLDEST_ENVIRONMENTS=$(echo "$FILTERED_ENVS" \
-		| grep -v "^${PANTHEON_TARGET_ENV}$" \
-		| sort \
-		| sed -e '$d')
+	# Exclude the current target environment and all environments with the same prefix
+	CANDIDATE_ENVS=$(echo "$FILTERED_ENVS" \
+		| grep -v "^${PANTHEON_TARGET_ENV}$")
+
+	# If we have a prefix, exclude all environments starting with that prefix
+	if [ -n "$ENV_PREFIX" ]; then
+		CANDIDATE_ENVS=$(echo "$CANDIDATE_ENVS" | grep -v "^${ENV_PREFIX}-")
+	fi
+
+	# Filter by age and collect environments with their timestamps for sorting
+	OLDEST_ENVIRONMENTS=""
+	for ENV in $CANDIDATE_ENVS; do
+		# Get the last modified timestamp for this environment
+		CREATED_TIMESTAMP=$(terminus env:info "${PANTHEON_SITE}.${ENV}" --field=created 2>/dev/null || echo "0")
+
+		# Calculate age in seconds
+		AGE_SECONDS=$((CURRENT_TIMESTAMP - CREATED_TIMESTAMP))
+
+		# Only include if older than threshold
+		if [ "$AGE_SECONDS" -gt "$AGE_THRESHOLD_SECONDS" ]; then
+			AGE_DAYS=$((AGE_SECONDS / 86400))
+			echo -e "${yellow}Found old environment: ${normal}${bold}${ENV}${normal}${yellow} (${AGE_DAYS} days old)${normal}"
+			# Add to list with timestamp for sorting (format: timestamp env_name)
+			OLDEST_ENVIRONMENTS="${OLDEST_ENVIRONMENTS}${CREATED_TIMESTAMP} ${ENV}"$'\n'
+		fi
+	done
+
+	# Sort by timestamp (oldest first) and extract just the environment names
+	OLDEST_ENVIRONMENTS=$(echo "$OLDEST_ENVIRONMENTS" | grep -v '^$' | sort -n | awk '{print $2}')
 
 	# Exit if there are no environments to delete.
 	if [ -z "$OLDEST_ENVIRONMENTS" ] ; then


### PR DESCRIPTION
  Replace single deployment jobs with 5 concurrent test suites that cover
  all 11 optional input parameters across realistic deployment scenarios.

  Test suites:
  - Standard: Default parameters with Build Tools mode
  - Content: Tests clone_content and source_env variations
  - Git-Only: Tests skip_build_tools with custom git config
  - Terminus Pre-installed: Tests skip_terminus_install and build_tools_version
  - Advanced: Tests relative_site_root and delete_old_environments cleanup

  Environment naming:
  - PR deployments: {num}-{suite} (e.g., 123-std, 123-cont)
  - Manual deployments: {branch}-{suite} with 6-char branch limit
    - 0.x branch: 0x-{suite}
    - Other branches: {6char}-{suite} (e.g., 126mor-std)
  - Max 11 chars, fits Pantheon's limit

  New workflow structure:
  - .github/workflows/test-suites.yml: Reusable workflow with 5 concurrent jobs
  - deploy-pr.yml: Calls test-suites.yml with PR number as env_prefix
  - manual-deploy.yml: Computes env_prefix from branch, adds suite selection

  Enhanced cleanup in scripts/main.sh:
  - Supports built-in patterns (-std, -cont, -git, -term, -adv, wd-*)
  - Optional MULTIDEV_DELETE_PATTERN for custom cleanup
  - Backward compatible with legacy pr-{num} and wd-{branch} patterns
  - Always protects current target environment

Partially addresses #126 