### PR TITLE
Fix release workflow: prevent bot comment loops and correct version display

### DIFF
--- a/.github/workflows/auto-release-pr.yml
+++ b/.github/workflows/auto-release-pr.yml
@@ -115,7 +115,7 @@ jobs:
           echo "  actions/checkout: $CHECKOUT_VERSION"
           echo "  actions/cache: $CACHE_VERSION"
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
 
       - name: Check if release PR exists
         id: check_pr
@@ -132,7 +132,7 @@ jobs:
             echo "No existing release PR found"
           fi
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
 
       - name: Configure Git
         run: |
@@ -210,7 +210,7 @@ jobs:
       - name: Create or update PR
         if: steps.commit.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
           NEW_VERSION: ${{ steps.version.outputs.new_version }}
           BRANCH_NAME: ${{ steps.branch.outputs.branch_name }}
           LATEST_TAG: ${{ steps.version.outputs.latest_tag }}
@@ -264,7 +264,7 @@ jobs:
       - name: Comment on trigger PR
         if: github.event_name == 'pull_request_target' && github.event.pull_request.merged == true
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           NEW_VERSION: ${{ steps.version.outputs.new_version }}
         run: |
@@ -274,7 +274,7 @@ jobs:
       - name: React to version override comment
         if: github.event_name == 'issue_comment' && steps.check_comment.outputs.has_override == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
           REPO: ${{ github.repository }}
           COMMENT_ID: ${{ github.event.comment.id }}
         run: |

--- a/.github/workflows/auto-release-pr.yml
+++ b/.github/workflows/auto-release-pr.yml
@@ -210,6 +210,7 @@ jobs:
       - name: Create or update PR
         if: steps.commit.outputs.has_changes == 'true'
         env:
+          GH_TOKEN: ${{ github.token }}
           NEW_VERSION: ${{ steps.version.outputs.new_version }}
           BRANCH_NAME: ${{ steps.branch.outputs.branch_name }}
           LATEST_TAG: ${{ steps.version.outputs.latest_tag }}
@@ -259,8 +260,6 @@ jobs:
               --draft
             echo "Created new draft PR"
           fi
-        env:
-          GH_TOKEN: ${{ github.token }}
 
       - name: Comment on trigger PR
         if: github.event_name == 'pull_request_target' && github.event.pull_request.merged == true

--- a/.github/workflows/auto-release-pr.yml
+++ b/.github/workflows/auto-release-pr.yml
@@ -117,30 +117,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Update versions in README
-        env:
-          LATEST_TAG: ${{ steps.version.outputs.latest_tag }}
-          NEW_VERSION: ${{ steps.version.outputs.new_version }}
-          CHECKOUT_VERSION: ${{ steps.action_versions.outputs.checkout }}
-          CACHE_VERSION: ${{ steps.action_versions.outputs.cache }}
-        run: |
-          # Escape dots for sed
-          LATEST_TAG_ESCAPED=$(echo "$LATEST_TAG" | sed 's/\./\\./g')
-
-          # Update pantheon-systems/push-to-pantheon version references
-          # Only update semantic version tags, not branch references
-          sed -i "s|pantheon-systems/push-to-pantheon@${LATEST_TAG_ESCAPED}|pantheon-systems/push-to-pantheon@${NEW_VERSION}|g" readme.md
-
-          # Update actions/checkout to latest (only update major version references like @v6)
-          CHECKOUT_MAJOR=$(echo "$CHECKOUT_VERSION" | grep -oE '^v[0-9]+')
-          sed -i "s|actions/checkout@v[0-9]\+|actions/checkout@${CHECKOUT_MAJOR}|g" readme.md
-
-          # Update actions/cache to latest
-          CACHE_MAJOR=$(echo "$CACHE_VERSION" | grep -oE '^v[0-9]+')
-          sed -i "s|actions/cache@v[0-9]\+|actions/cache@${CACHE_MAJOR}|g" readme.md
-
-          echo "Updated README.md with new versions"
-
       - name: Check if release PR exists
         id: check_pr
         run: |
@@ -184,6 +160,30 @@ jobs:
           fi
 
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+      - name: Update versions in README
+        env:
+          LATEST_TAG: ${{ steps.version.outputs.latest_tag }}
+          NEW_VERSION: ${{ steps.version.outputs.new_version }}
+          CHECKOUT_VERSION: ${{ steps.action_versions.outputs.checkout }}
+          CACHE_VERSION: ${{ steps.action_versions.outputs.cache }}
+        run: |
+          # Escape dots for sed
+          LATEST_TAG_ESCAPED=$(echo "$LATEST_TAG" | sed 's/\./\\./g')
+
+          # Update pantheon-systems/push-to-pantheon version references
+          # Only update semantic version tags, not branch references
+          sed -i "s|pantheon-systems/push-to-pantheon@${LATEST_TAG_ESCAPED}|pantheon-systems/push-to-pantheon@${NEW_VERSION}|g" readme.md
+
+          # Update actions/checkout to latest (only update major version references like @v6)
+          CHECKOUT_MAJOR=$(echo "$CHECKOUT_VERSION" | grep -oE '^v[0-9]+')
+          sed -i "s|actions/checkout@v[0-9]\+|actions/checkout@${CHECKOUT_MAJOR}|g" readme.md
+
+          # Update actions/cache to latest
+          CACHE_MAJOR=$(echo "$CACHE_VERSION" | grep -oE '^v[0-9]+')
+          sed -i "s|actions/cache@v[0-9]\+|actions/cache@${CACHE_MAJOR}|g" readme.md
+
+          echo "Updated README.md with new versions"
 
       - name: Commit version changes
         id: commit

--- a/.github/workflows/auto-release-pr.yml
+++ b/.github/workflows/auto-release-pr.yml
@@ -120,13 +120,16 @@ jobs:
       - name: Check if release PR exists
         id: check_pr
         run: |
-          # Check for existing release PR
-          PR_NUMBER=$(gh pr list --base 0.x --state open --json number,title --jq '.[] | select(.title | startswith("Release ")) | .number' | head -1)
+          # Check for existing release PR and get its head branch
+          PR_DATA=$(gh pr list --base 0.x --state open --json number,title,headRefName --jq '.[] | select(.title | startswith("Release "))' | head -1)
 
-          if [ -n "$PR_NUMBER" ]; then
+          if [ -n "$PR_DATA" ]; then
+            PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number')
+            HEAD_BRANCH=$(echo "$PR_DATA" | jq -r '.headRefName')
             echo "exists=true" >> $GITHUB_OUTPUT
             echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
-            echo "Found existing release PR #$PR_NUMBER"
+            echo "head_branch=$HEAD_BRANCH" >> $GITHUB_OUTPUT
+            echo "Found existing release PR #$PR_NUMBER (branch: $HEAD_BRANCH)"
           else
             echo "exists=false" >> $GITHUB_OUTPUT
             echo "No existing release PR found"
@@ -139,15 +142,44 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Close old PR if version changed
+        if: steps.check_pr.outputs.exists == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          PR_NUMBER: ${{ steps.check_pr.outputs.pr_number }}
+          OLD_BRANCH: ${{ steps.check_pr.outputs.head_branch }}
+          NEW_VERSION: ${{ steps.version.outputs.new_version }}
+        run: |
+          NEW_BRANCH="release-${NEW_VERSION}"
+
+          # If the branch name changed (version override), close old PR
+          if [ "$OLD_BRANCH" != "$NEW_BRANCH" ]; then
+            echo "Version changed, closing old PR #$PR_NUMBER (branch: $OLD_BRANCH)"
+            gh pr close "$PR_NUMBER" --comment "Closing this PR because the version was changed. A new PR will be created for version $NEW_VERSION."
+
+            # Delete the old branch
+            git push origin --delete "$OLD_BRANCH" || echo "Branch $OLD_BRANCH already deleted or doesn't exist"
+
+            echo "Closed old PR and deleted branch $OLD_BRANCH"
+          else
+            echo "Same version, will update existing PR"
+          fi
+
       - name: Create or update release branch
         id: branch
         env:
           NEW_VERSION: ${{ steps.version.outputs.new_version }}
+          PR_EXISTS: ${{ steps.check_pr.outputs.exists }}
+          OLD_BRANCH: ${{ steps.check_pr.outputs.head_branch }}
         run: |
           BRANCH_NAME="release-${NEW_VERSION}"
 
-          # Check if branch exists
-          if git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
+          # Check if we closed the old PR (different version)
+          if [ "$PR_EXISTS" = "true" ] && [ "$OLD_BRANCH" != "$BRANCH_NAME" ]; then
+            echo "Creating new branch for version override: $BRANCH_NAME"
+            git checkout -b "$BRANCH_NAME"
+          # Check if branch already exists
+          elif git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
             echo "Branch $BRANCH_NAME exists, checking it out"
             git fetch origin "$BRANCH_NAME"
             git checkout "$BRANCH_NAME"
@@ -238,8 +270,10 @@ jobs:
           4. Merge this PR
           5. Run the **Create Release** workflow to publish the release"
 
-          if [ "${{ steps.check_pr.outputs.exists }}" = "true" ]; then
-            # Update existing PR
+          # Check if we need to create new PR or update existing
+          # If old branch exists but differs from new branch, we closed it and need to create new
+          if [ "${{ steps.check_pr.outputs.exists }}" = "true" ] && [ "${{ steps.check_pr.outputs.head_branch }}" = "$BRANCH_NAME" ]; then
+            # Update existing PR (same branch)
             PR_NUMBER="${{ steps.check_pr.outputs.pr_number }}"
             gh pr edit "$PR_NUMBER" \
               --title "Release $NEW_VERSION" \
@@ -250,7 +284,7 @@ jobs:
 
             echo "Updated existing PR #$PR_NUMBER"
           else
-            # Create new PR in draft mode with release label
+            # Create new PR (either no PR exists, or we closed the old one due to version change)
             gh pr create \
               --base 0.x \
               --head "$BRANCH_NAME" \
@@ -258,7 +292,7 @@ jobs:
               --body "$PR_BODY" \
               --label "release" \
               --draft
-            echo "Created new draft PR"
+            echo "Created new draft PR for $NEW_VERSION"
           fi
 
       - name: Comment on trigger PR

--- a/.github/workflows/auto-release-pr.yml
+++ b/.github/workflows/auto-release-pr.yml
@@ -27,11 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     # Only run if:
     # 1. Non-release PR was merged to 0.x (don't trigger when release PR is merged), OR
-    # 2. Comment on a release PR, OR
+    # 2. Comment on a release PR (but not from bot), OR
     # 3. Release PR was edited
     if: |
       (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true && !startsWith(github.event.pull_request.title, 'Release ')) ||
-      (github.event_name == 'issue_comment' && startsWith(github.event.issue.title, 'Release ')) ||
+      (github.event_name == 'issue_comment' && startsWith(github.event.issue.title, 'Release ') && github.event.comment.user.login != 'github-actions[bot]') ||
       (github.event_name == 'pull_request' && startsWith(github.event.pull_request.title, 'Release '))
 
     steps:
@@ -59,9 +59,9 @@ jobs:
 
       - name: Check for version override in PR title
         id: check_title
-        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target' || github.event_name == 'issue_comment'
         env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_TITLE: ${{ github.event_name == 'issue_comment' && github.event.issue.title || github.event.pull_request.title }}
         run: |
           # Extract version from "Release X.Y.Z" title
           if echo "$PR_TITLE" | grep -qE '^Release [0-9]+\.[0-9]+\.[0-9]+'; then
@@ -249,12 +249,16 @@ jobs:
           CHECKOUT_VERSION: ${{ steps.action_versions.outputs.checkout }}
           CACHE_VERSION: ${{ steps.action_versions.outputs.cache }}
         run: |
+          # Extract major versions only (v6 from v6.0.2, v5 from v5.0.3)
+          CHECKOUT_MAJOR=$(echo "$CHECKOUT_VERSION" | grep -oE '^v[0-9]+')
+          CACHE_MAJOR=$(echo "$CACHE_VERSION" | grep -oE '^v[0-9]+')
+
           PR_BODY="This PR updates version references in the README from \`$LATEST_TAG\` to \`$NEW_VERSION\`.
 
           ## Changes
           - Updated \`pantheon-systems/push-to-pantheon\` references to \`$NEW_VERSION\`
-          - Updated \`actions/checkout\` to \`$CHECKOUT_VERSION\`
-          - Updated \`actions/cache\` to \`$CACHE_VERSION\`
+          - Updated \`actions/checkout\` to \`$CHECKOUT_MAJOR\`
+          - Updated \`actions/cache\` to \`$CACHE_MAJOR\`
 
           ## Version Override
           You can override the version by:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Create GitHub Draft Release
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
           VERSION: ${{ steps.version.outputs.version }}
           REPO: ${{ github.repository }}
         run: |
@@ -109,7 +109,7 @@ jobs:
       - name: Comment on merged PR
         if: github.event_name == 'pull_request_target'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
           VERSION: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
Three critical fixes to auto-release-pr.yml:

1. **Check PR title for all event types**: The "Check for version override
   in PR title" step now runs for issue_comment events too, not just
   pull_request events. This ensures the workflow always knows what version
   the release PR is for, regardless of how it was triggered.

2. **Skip bot comments**: Added filter to job condition to skip workflow runs
   triggered by github-actions[bot] comments. This prevents infinite loops
   where the workflow's own automated "Closing this PR..." comments would
   trigger new runs.

3. **Show major versions only in PR body**: Extract major versions (v6, v5)
   from full versions (v6.0.2, v5.0.3) when generating PR body. This matches
   what's actually updated in the README (major versions only).

These fixes prevent the bug where editing a release PR title from "Release
0.8.1" to "Release 0.9.0" would create a new PR with the correct version,
but then the workflow's own comment would trigger another run that created
a third PR with version 0.8.1 (auto-incremented from latest tag).