### PR TITLE
Add output for target environment and target environment url

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -78,6 +78,13 @@ inputs:
 
   # todo checkout_repo:
   #   description: "A boolean for whether or not this composite step should checkout the git repo. Set to false if a checkout has already been perf"
+outputs:
+  target_env:
+    description: "The target environment the branch was deployed to"
+    value: ${{ env.PANTHEON_TARGET_ENV }}
+  target_env_url:
+    description: "The url for the target environment the branch was deployed to"
+    value: https://${{ env.PANTHEON_TARGET_ENV }}-${{ inputs.site }}.pantheonsite.io
 
 runs:
     using: 'composite'

--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,12 @@ jobs:
 
 <!-- AUTO-DOC-INPUT:END -->
 
+## Outputs
+
+<!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
+
+<!-- AUTO-DOC-OUTPUT:END -->
+
 ## Parameters
 
 In order to use the step supplied by this Action, the GitHub Workflow must have access to [a token for authenticating with Pantheon's command line](https://docs.pantheon.io/machine-tokens) and [a private key](https://docs.pantheon.io/ssh-keys) that will allow Git pushes to Pantheon and other operations.


### PR DESCRIPTION
The push-to-pantheon action calculates the target environment and the target environment URL in order to perform its deploy. Unfortunately, it doesn't output that information to be used by future steps or jobs in the same workflow. For example, someone might want to do end-to-end testing on the newly created multi-dev. This PR adds two outputs to the action: `target_env` and `target_env_url` which make that information available to other steps in the Github Actions workflow.