### PR TITLE
Correct bug in outputting the target env and target env url

### DIFF
--- a/.github/workflows/test-suites.yml
+++ b/.github/workflows/test-suites.yml
@@ -268,11 +268,28 @@ jobs:
           relative_site_root: ${{ github.event_name == 'pull_request_target' && 'pr-code/.github/testing_fixtures/dtp-nearly-empty-site' || '.github/testing_fixtures/dtp-nearly-empty-site' }}
           delete_old_environments: true
           clone_content: true
+        id: deploy_to_pantheon          
 
       - name: Verify deployment success
         run: |
           echo "Deployment completed successfully"
           echo "Environment: ${{ inputs.env_prefix }}-adv"
+      
+      - name: Verify target environment and url output from action
+        run: |
+          TARGET_ENV_URL="https://${{ inputs.env_prefix }}-adv-dtp-nearly-empty-site.pantheonsite.io"
+          TARGET_ENV="${{ inputs.env_prefix }}-adv"
+          echo "Checking whether the target environment output from the action matches ${TARGET_ENV}"
+          if [[ "${{ steps.deploy_to_pantheon.outputs.target_env }}" != "${TARGET_ENV}""]]; then
+            echo "::error::❌ deploy to pantheon output a target_env of ${{ steps.deploy_to_pantheon.outputs.target_env }}"
+            exit 1
+          fi
+          
+          echo "Checking whether the target environment url output from the action matches ${TARGET_ENV_URL}"
+          if [[ "${{ steps.deploy_to_pantheon.outputs.target_env_url }}" != "${TARGET_ENV_URL}""]]; then
+            echo "::error::❌ Environment URL is not accessible"
+            exit 1
+          fi
 
       - name: Check environment URL accessibility
         run: |

--- a/action.yml
+++ b/action.yml
@@ -78,6 +78,13 @@ inputs:
 
   # todo checkout_repo:
   #   description: "A boolean for whether or not this composite step should checkout the git repo. Set to false if a checkout has already been perf"
+outputs:
+  target_env:
+    description: "The target environment the branch was deployed to"
+    value: ${{ env.PANTHEON_TARGET_ENV }}
+  target_env_url:
+    description: "The url for the target environment the branch was deployed to"
+    value: https://${{ env.PANTHEON_TARGET_ENV }}-${{ inputs.site }}.pantheonsite.io
 
 runs:
     using: 'composite'

--- a/action.yml
+++ b/action.yml
@@ -81,10 +81,10 @@ inputs:
 outputs:
   target_env:
     description: "The target environment the branch was deployed to"
-    value: ${{ env.PANTHEON_TARGET_ENV }}
+    value: ${{ steps.set_target_env.outputs.PANTHEON_TARGET_ENV }}
   target_env_url:
     description: "The url for the target environment the branch was deployed to"
-    value: https://${{ env.PANTHEON_TARGET_ENV }}-${{ inputs.site }}.pantheonsite.io
+    value: https://${{ steps.set_target_env.outputs.PANTHEON_TARGET_ENV }}-${{ inputs.site }}.pantheonsite.io
 
 runs:
     using: 'composite'
@@ -102,6 +102,7 @@ runs:
           echo "PANTHEON_TARGET_ENV<<EOF" >> $GITHUB_ENV
           echo "${TARGET_ENV}" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
+          echo "PANTHEON_TARGET_ENV=${value}" >> "$GITHUB_OUTPUT"
 
       - name: Set clone content flag
         shell: bash

--- a/action.yml
+++ b/action.yml
@@ -102,7 +102,7 @@ runs:
           echo "PANTHEON_TARGET_ENV<<EOF" >> $GITHUB_ENV
           echo "${TARGET_ENV}" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
-          echo "PANTHEON_TARGET_ENV=${value}" >> "$GITHUB_OUTPUT"
+          echo "PANTHEON_TARGET_ENV=${TARGET_ENV}" >> "$GITHUB_OUTPUT"
 
       - name: Set clone content flag
         shell: bash

--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,12 @@ jobs:
 
 <!-- AUTO-DOC-INPUT:END -->
 
+## Outputs
+
+<!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
+
+<!-- AUTO-DOC-OUTPUT:END -->
+
 ## Parameters
 
 In order to use the step supplied by this Action, the GitHub Workflow must have access to [a token for authenticating with Pantheon's command line](https://docs.pantheon.io/machine-tokens) and [a private key](https://docs.pantheon.io/ssh-keys) that will allow Git pushes to Pantheon and other operations.


### PR DESCRIPTION
I made a mistake in #153. The target env and url weren't being filled but they are now (which I've tested in a private repo). Sorry about that!

I added a test into one of the test workflows but, since you're not using pull_request_target, it's not actually running on the checks right now. You may want to run that to verify it's working.