### PR TITLE
Fix multidev limit checks for specific environments

### DIFF
--- a/.github/workflows/test-suites.yml
+++ b/.github/workflows/test-suites.yml
@@ -280,13 +280,13 @@ jobs:
           TARGET_ENV_URL="https://${{ inputs.env_prefix }}-adv-dtp-nearly-empty-site.pantheonsite.io"
           TARGET_ENV="${{ inputs.env_prefix }}-adv"
           echo "Checking whether the target environment output from the action matches ${TARGET_ENV}"
-          if [[ "${{ steps.deploy_to_pantheon.outputs.target_env }}" != "${TARGET_ENV}""]]; then
+          if [[ "${{ steps.deploy_to_pantheon.outputs.target_env }}" != "${TARGET_ENV}" ]]; then
             echo "::error::❌ deploy to pantheon output a target_env of ${{ steps.deploy_to_pantheon.outputs.target_env }}"
             exit 1
           fi
-          
+
           echo "Checking whether the target environment url output from the action matches ${TARGET_ENV_URL}"
-          if [[ "${{ steps.deploy_to_pantheon.outputs.target_env_url }}" != "${TARGET_ENV_URL}""]]; then
+          if [[ "${{ steps.deploy_to_pantheon.outputs.target_env_url }}" != "${TARGET_ENV_URL}" ]]; then
             echo "::error::❌ Environment URL is not accessible"
             exit 1
           fi

--- a/action.yml
+++ b/action.yml
@@ -203,7 +203,7 @@ runs:
           fi
 
       - name: Check multidev limit
-        if: ${{ env.PANTHEON_TARGET_ENV != 'dev' && env.PANTHEON_TARGET_ENV != 'test' && env.PANTHEON_TARGET_ENV != 'live' }}
+        if: ${{ inputs.target_env == '' && env.PANTHEON_TARGET_ENV != 'dev' && env.PANTHEON_TARGET_ENV != 'test' && env.PANTHEON_TARGET_ENV != 'live' }}
         id: check_multidev_limit
         shell: bash
         env:
@@ -212,7 +212,7 @@ runs:
           ${GITHUB_ACTION_PATH}/scripts/main.sh check_multidev_limit
 
       - name: Comment on PR if multidev limit reached
-        if: ${{ env.PANTHEON_TARGET_ENV != 'dev' && env.PANTHEON_TARGET_ENV != 'test' && env.PANTHEON_TARGET_ENV != 'live' && steps.check_multidev_limit.outputs.multidev_available == 'false' }}
+        if: ${{ inputs.target_env == '' && env.PANTHEON_TARGET_ENV != 'dev' && env.PANTHEON_TARGET_ENV != 'test' && env.PANTHEON_TARGET_ENV != 'live' && steps.check_multidev_limit.outputs.multidev_available == 'false' }}
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -230,7 +230,7 @@ runs:
           For more information, see the [Pantheon Multidev documentation](https://pantheon.io/docs/multidev)."
 
       - name: Abort deployment if multidev limit reached
-        if: ${{ env.PANTHEON_TARGET_ENV != 'dev' && env.PANTHEON_TARGET_ENV != 'test' && env.PANTHEON_TARGET_ENV != 'live' && steps.check_multidev_limit.outputs.multidev_available == 'false' }}
+        if: ${{ inputs.target_env == '' && env.PANTHEON_TARGET_ENV != 'dev' && env.PANTHEON_TARGET_ENV != 'test' && env.PANTHEON_TARGET_ENV != 'live' && steps.check_multidev_limit.outputs.multidev_available == 'false' }}
         shell: bash
         run: |
           echo "::error::Aborting deployment: Multidev limit reached. Delete unused environments or contact Pantheon to increase your limit."

--- a/action.yml
+++ b/action.yml
@@ -203,7 +203,7 @@ runs:
           fi
 
       - name: Check multidev limit
-        if: ${{ inputs.target_env == '' }}
+        if: ${{ env.PANTHEON_TARGET_ENV != 'dev' && env.PANTHEON_TARGET_ENV != 'test' && env.PANTHEON_TARGET_ENV != 'live' }}
         id: check_multidev_limit
         shell: bash
         env:
@@ -212,7 +212,7 @@ runs:
           ${GITHUB_ACTION_PATH}/scripts/main.sh check_multidev_limit
 
       - name: Comment on PR if multidev limit reached
-        if: ${{ inputs.target_env == '' && steps.check_multidev_limit.outputs.multidev_available == 'false' }}
+        if: ${{ env.PANTHEON_TARGET_ENV != 'dev' && env.PANTHEON_TARGET_ENV != 'test' && env.PANTHEON_TARGET_ENV != 'live' && steps.check_multidev_limit.outputs.multidev_available == 'false' }}
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -230,7 +230,7 @@ runs:
           For more information, see the [Pantheon Multidev documentation](https://pantheon.io/docs/multidev)."
 
       - name: Abort deployment if multidev limit reached
-        if: ${{ inputs.target_env == '' && steps.check_multidev_limit.outputs.multidev_available == 'false' }}
+        if: ${{ env.PANTHEON_TARGET_ENV != 'dev' && env.PANTHEON_TARGET_ENV != 'test' && env.PANTHEON_TARGET_ENV != 'live' && steps.check_multidev_limit.outputs.multidev_available == 'false' }}
         shell: bash
         run: |
           echo "::error::Aborting deployment: Multidev limit reached. Delete unused environments or contact Pantheon to increase your limit."


### PR DESCRIPTION
Update the multidev limit checks to exclude dev, test, and live environments, ensuring that the checks only apply to other environments. This change prevents unnecessary limit checks during deployments in these specific environments and fixes the issue where deploys were being blocked if the number of available multidevs was 0.

fixes #162