### PR TITLE
Update pull request permissions to allow commenting

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -35,7 +35,7 @@ jobs:
     permissions:
       deployments: write
       contents: write
-      pull-requests: read
+      pull-requests: write
     uses: ./.github/workflows/test-suites.yml
     with:
       env_prefix: ${{ github.event.pull_request.number || 'manual' }}

--- a/.github/workflows/test-suites.yml
+++ b/.github/workflows/test-suites.yml
@@ -39,7 +39,7 @@ on:
 permissions:
   deployments: write
   contents: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   standard:

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ jobs:
     permissions:
       deployments: write
       contents: read
-      pull-requests: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -325,7 +325,7 @@ This action needs permission to perform its work. Set the following permissions 
     permissions:
       deployments: write
       contents: read
-      pull-requests: read
+      pull-requests: write
 ```
 
 The `deployments: write` permission is required to notify GitHub that the deployment has been made (to a Pantheon Multidev usually).
@@ -336,7 +336,7 @@ This is required for the GitHub UI to show the deployment status of the pull req
 The `contents: read` permission is required for the job to check out the code from the GitHub repository.
 Even though this action does not checkout of the code itself, the code must be checked out prior to this step in order for the action to work.
 
-The `pull-requests: read` permission is required to delete old Multidev environments associated with closed pull requests.
+The `pull-requests: write` permission is required for two things: reading pull request state in order to delete old Multidev environments associated with closed pull requests, and posting a comment on the pull request when a site's Multidev environment limit has been reached.
 
 [See the GitHub Actions documentation for more information on permissions.](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token)
 
@@ -358,7 +358,7 @@ jobs:
     permissions:
       deployments: write
       contents: write # needed to checkout the PR code.
-      pull-requests: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     # Checkout the base repository code into the root directory.

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -158,6 +158,8 @@ function check_missing_permissions() {
 	fi
 
 	# Check pull-requests permission (only if this is a PR event)
+	# Requires pull-requests: write; this GET only confirms read access since
+	# there's no non-mutating way to probe for write.
 	if [ -n "${PR_NUMBER}" ]; then
 		PR_RESPONSE=$(curl -s -w "\n%{http_code}" \
 			-H "Authorization: token ${GITHUB_TOKEN}" \
@@ -166,7 +168,7 @@ function check_missing_permissions() {
 		PR_HTTP_CODE=$(echo "$PR_RESPONSE" | tail -n1)
 
 		if [ "$PR_HTTP_CODE" = "403" ]; then
-			MISSING_PERMISSIONS+=("pull-requests: read")
+			MISSING_PERMISSIONS+=("pull-requests: write")
 		fi
 	fi
 
@@ -240,7 +242,7 @@ function get_missing_permissions_help() {
 	echo "    permissions:"
 	echo "      deployments: write"
 	echo "      contents: read"
-	echo "      pull-requests: read"
+	echo "      pull-requests: write"
 	echo ""
 	echo "For more information, see:"
 	echo "https://github.com/pantheon-systems/push-to-pantheon#permissions"

--- a/tests/03-permissions.bats
+++ b/tests/03-permissions.bats
@@ -47,7 +47,7 @@ teardown() {
     assert_output_contains "Missing required GitHub permissions"
     assert_output_contains "deployments: write"
     assert_output_contains "contents: read"
-    assert_output_contains "pull-requests: read"
+    assert_output_contains "pull-requests: write"
     assert_output_contains "permissions:"
 }
 


### PR DESCRIPTION
Change pull request permissions from read to write to enable commenting on pull requests and update related documentation and tests accordingly.

`pull-request: write` is required for the action to comment on pull requests when the multidev limit has been reached. previously this was silently failing.