### PR TITLE
docs: document manual signing step for release PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 ## Cutting a release
 
-Releases are **fully automated** through GitHub workflows. The process requires minimal human intervention.
+Releases are **mostly automated** through GitHub workflows, with one required manual step (signing the release PR's version-bump commit — see step 3 below).
 
 ### Automated Release Flow
 
@@ -26,7 +26,20 @@ By default, the patch version is incremented. For minor or major bumps:
 
 The workflow automatically updates the release branch with the new version.
 
-**3. Merge release PR → Draft release is created**
+**3. Manually sign the version-bump commit (required)**
+
+The org enforces a `required_signatures` ruleset on `0.x`, but the release PR's version-bump commit is created by automation and is **not** GPG/SSH signed — GitHub only auto-signs commits made via a GitHub App installation token, and this repo's automation authenticates with a personal PAT (`GH_PAT`), which doesn't qualify. This means the release PR will show as blocked (merging disabled) until the commit is manually replaced with a signed one:
+
+```bash
+git fetch origin release-X.Y.Z
+git checkout release-X.Y.Z
+git commit --amend --reset-author -S --no-edit
+git push --force-with-lease origin release-X.Y.Z
+```
+
+This requires commit signing to be configured locally (`user.signingkey` + `commit.gpgsign true`, or SSH signing). Confirm it worked with `git log -1 --format='%G?'` (should print `G` or `U`, not `N`) before pushing. There is currently no fully-automated way around this step — see the PR discussion on [#165](https://github.com/pantheon-systems/push-to-pantheon/pull/165) for why (GitHub App-based signing was considered but not pursued).
+
+**4. Merge release PR → Draft release is created**
 
 When you merge the release PR:
 1. Mark the draft PR as **Ready for review**
@@ -37,7 +50,7 @@ When you merge the release PR:
    - Creates a **draft GitHub release** with auto-generated notes
    - Comments on the merged PR with a link to the release
 
-**4. Publish the release**
+**5. Publish the release**
 
 Navigate to the [Releases page](https://github.com/pantheon-systems/push-to-pantheon/releases) and:
 1. Review the draft release notes


### PR DESCRIPTION
## Problem

#165 moved the release PR's version-bump commit to be created via the GitHub Contents API, on the assumption that API-created commits are automatically GPG-signed by GitHub. That assumption was wrong for our case: GitHub only auto-signs API-created commits when authored via a **GitHub App installation token**. This repo's automation authenticates with `secrets.GH_PAT` (a personal PAT), so the commit is still unsigned — confirmed via the GitHub API on PR #166's commit:

```json
{"reason": "unsigned", "signature": null, "verified": false}
```

Since the org enforces a `required_signatures` ruleset on `0.x`, every release PR is blocked from merging until someone manually amends the version-bump commit with a real signature and force-pushes it (as done for 0.9.3, and needed again for 0.9.4/#166).

## Solution

No further workflow changes for now — setting up a GitHub App (the only fully-automated fix) or a bot GPG key both add meaningful ongoing overhead for a single commit per release. Instead, document the required manual step in `CONTRIBUTING.md`'s release process so it doesn't need rediscovering:

```bash
git fetch origin release-X.Y.Z
git checkout release-X.Y.Z
git commit --amend --reset-author -S --no-edit
git push --force-with-lease origin release-X.Y.Z
```

Also updates the "fully automated" claim at the top of the release section to reflect this one manual step.