### PR TITLE
docs: fix repository typo in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ When running on workflows triggered by merges/pushes to the `main` branch this a
 
 ## Early Access
 
-As a publicly available GitHub Action, there is no gating mechanism preventing any Pantheon customer from using the code in this repository. However, this reposistory is in active development and behaviors may change between versions. Only teams with pre-existing Continuous Integration pipelines that they could fall back to, should try this repository at this time. [See our documentation for more information about software maturity and support](https://docs.pantheon.io/oss-support-levels#early-access).
+As a publicly available GitHub Action, there is no gating mechanism preventing any Pantheon customer from using the code in this repository. However, this repository is in active development and behaviors may change between versions. Only teams with pre-existing Continuous Integration pipelines that they could fall back to, should try this repository at this time. [See our documentation for more information about software maturity and support](https://docs.pantheon.io/oss-support-levels#early-access).
 
 ## Related Resources
 


### PR DESCRIPTION
# PR Draft: pantheon-systems/push-to-pantheon#168

Title:

```text
docs: fix repository typo in README
```

Body:

```markdown
## Summary
- Fixes a README typo: `reposistory` -> `repository`.

## Verification
- `git diff --check`
- `rg -n "reposistory" readme.md`

Closes #168
```

## Local Verification

```bash
git -C work/push-to-pantheon diff --check
rg -n "reposistory" work/push-to-pantheon/readme.md
rg -n "this repository is in active development" work/push-to-pantheon/readme.md
```

Result:

- `git diff --check`: PASS.
- Stale typo grep: no matches.
- Corrected README sentence present.
